### PR TITLE
Phase 3.1: Academic Year / Semester / Subject module

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -35,6 +35,9 @@ http://localhost:8080/api/swagger-ui.html
 | Staff | `/v1/staff/*` | Employee records |
 | Students | `/v1/students/*` | Student profiles |
 | Classes | `/v1/classes/*` | Homeroom class CRUD, GVCN assignment, roster |
+| Academic Years | `/v1/academic-years/*` | Năm học CRUD + close |
+| Semesters | `/v1/semesters/*` | Học kỳ (HK1/HK2) CRUD |
+| Subjects | `/v1/subjects/*` | Môn học CRUD |
 | Attendance | `/v1/attendance/*` | Daily attendance |
 | Grades | `/v1/grades/*` | Assessments |
 | Fees | `/v1/fees/*` | Student fees & payments |
@@ -46,7 +49,8 @@ See [Swagger UI](http://localhost:8080/api/swagger-ui.html) for the full, curren
 ## 🗄️ Database
 
 - **MySQL 8.0**, local. Charset **`utf8mb4`** / collation **`utf8mb4_unicode_ci`** is required (plain `utf8` only supports 3-byte characters and mangles Vietnamese diacritics).
-- Schema is managed by **Flyway** (`src/main/resources/db/migration/V1__baseline.sql`, `V2__fix_classes_unique_constraint.sql`, ...) — `ddl-auto` is `validate`, never `update`. To change the schema, add a new `V{n}__description.sql` migration; don't hand-edit the DB or rely on Hibernate to create tables.
+- Schema is managed by **Flyway** (`src/main/resources/db/migration/`) — `ddl-auto` is `validate`, never `update`. To change the schema, add a new `V{n}__description.sql` migration; don't hand-edit the DB or rely on Hibernate to create tables.
+- `V3__academic_structure.sql` added `AcademicYear`/`Semester`/`Subject` and backfilled them from the old free-text data (`classes.academic_year`, `grades.subject`). The old columns this replaces (`SchoolClass.academicYear` String, `Student.className`/`section`) are kept and marked `@Deprecated` on the entity — not dropped — so nothing already built against them breaks; new code should read/write `SchoolClass.academicYearRef` and `Student.currentClass` instead.
 - Create the database once:
   ```sql
   CREATE DATABASE school_management CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -174,4 +178,4 @@ backend/
 
 ## 🚀 Future enhancements
 
-See the "Giai đoạn 3" section of [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) for the full roadmap — academic year/semester/subject entities, Thông tư 22/58 grading & xếp loại học lực, hạnh kiểm, thời khoá biểu, promotion workflow, parent portal & sổ liên lạc điện tử, admissions, PDF/Excel reports, audit log.
+See the "Giai đoạn 3" section of [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) for the full roadmap — Thông tư 22/58 grading & xếp loại học lực, hạnh kiểm, phân công giảng dạy & thời khoá biểu, promotion workflow, parent portal & sổ liên lạc điện tử, admissions, PDF/Excel reports, audit log. (Năm học/Học kỳ/Môn học — 3.1 — is done, above.)

--- a/backend/src/main/java/com/schoolmanagement/controller/AcademicYearController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/AcademicYearController.java
@@ -1,0 +1,67 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.dto.AcademicYearDTO;
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.service.AcademicYearService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/academic-years")
+@AllArgsConstructor
+@Tag(name = "Academic Years", description = "Năm học management endpoints")
+public class AcademicYearController {
+
+    private AcademicYearService academicYearService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Create academic year")
+    public ResponseEntity<AcademicYearDTO> createAcademicYear(@Valid @RequestBody AcademicYear academicYear) {
+        return new ResponseEntity<>(academicYearService.createAcademicYear(academicYear), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Update academic year")
+    public ResponseEntity<AcademicYearDTO> updateAcademicYear(@PathVariable Long id, @Valid @RequestBody AcademicYear details) {
+        return new ResponseEntity<>(academicYearService.updateAcademicYear(id, details), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get academic year by ID")
+    public ResponseEntity<AcademicYearDTO> getAcademicYearById(@PathVariable Long id) {
+        return new ResponseEntity<>(academicYearService.getAcademicYearById(id), HttpStatus.OK);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get all academic years")
+    public ResponseEntity<List<AcademicYearDTO>> getAllAcademicYears() {
+        return new ResponseEntity<>(academicYearService.getAllAcademicYears(), HttpStatus.OK);
+    }
+
+    @PutMapping("/{id}/close")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Close an academic year", description = "Marks it CLOSED; does not touch its classes/semesters/grades.")
+    public ResponseEntity<AcademicYearDTO> closeAcademicYear(@PathVariable Long id) {
+        return new ResponseEntity<>(academicYearService.closeAcademicYear(id), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Delete academic year", description = "Refused with 409 if it still has semesters or classes.")
+    public ResponseEntity<Void> deleteAcademicYear(@PathVariable Long id) {
+        academicYearService.deleteAcademicYear(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/controller/SemesterController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/SemesterController.java
@@ -1,0 +1,67 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.dto.SemesterDTO;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.service.SemesterService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/semesters")
+@AllArgsConstructor
+@Tag(name = "Semesters", description = "Học kỳ management endpoints")
+public class SemesterController {
+
+    private SemesterService semesterService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Create semester")
+    public ResponseEntity<SemesterDTO> createSemester(@Valid @RequestBody Semester semester) {
+        return new ResponseEntity<>(semesterService.createSemester(semester), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Update semester")
+    public ResponseEntity<SemesterDTO> updateSemester(@PathVariable Long id, @Valid @RequestBody Semester details) {
+        return new ResponseEntity<>(semesterService.updateSemester(id, details), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get semester by ID")
+    public ResponseEntity<SemesterDTO> getSemesterById(@PathVariable Long id) {
+        return new ResponseEntity<>(semesterService.getSemesterById(id), HttpStatus.OK);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get all semesters")
+    public ResponseEntity<List<SemesterDTO>> getAllSemesters() {
+        return new ResponseEntity<>(semesterService.getAllSemesters(), HttpStatus.OK);
+    }
+
+    @GetMapping("/academic-year/{academicYearId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get semesters for an academic year")
+    public ResponseEntity<List<SemesterDTO>> getSemestersByAcademicYear(@PathVariable Long academicYearId) {
+        return new ResponseEntity<>(semesterService.getSemestersByAcademicYear(academicYearId), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Delete semester")
+    public ResponseEntity<Void> deleteSemester(@PathVariable Long id) {
+        semesterService.deleteSemester(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/controller/SubjectController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/SubjectController.java
@@ -1,0 +1,60 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.dto.SubjectDTO;
+import com.schoolmanagement.entity.Subject;
+import com.schoolmanagement.service.SubjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/subjects")
+@AllArgsConstructor
+@Tag(name = "Subjects", description = "Môn học management endpoints")
+public class SubjectController {
+
+    private SubjectService subjectService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Create subject")
+    public ResponseEntity<SubjectDTO> createSubject(@Valid @RequestBody Subject subject) {
+        return new ResponseEntity<>(subjectService.createSubject(subject), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Update subject")
+    public ResponseEntity<SubjectDTO> updateSubject(@PathVariable Long id, @Valid @RequestBody Subject details) {
+        return new ResponseEntity<>(subjectService.updateSubject(id, details), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get subject by ID")
+    public ResponseEntity<SubjectDTO> getSubjectById(@PathVariable Long id) {
+        return new ResponseEntity<>(subjectService.getSubjectById(id), HttpStatus.OK);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get all subjects")
+    public ResponseEntity<List<SubjectDTO>> getAllSubjects() {
+        return new ResponseEntity<>(subjectService.getAllSubjects(), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Delete subject")
+    public ResponseEntity<Void> deleteSubject(@PathVariable Long id) {
+        subjectService.deleteSubject(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/AcademicYearDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/AcademicYearDTO.java
@@ -1,0 +1,36 @@
+package com.schoolmanagement.dto;
+
+import com.schoolmanagement.entity.AcademicYearStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Schema(description = "Năm học — spans roughly September to May of the following calendar year.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AcademicYearDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+
+    @Schema(example = "2025-2026")
+    private String name;
+
+    @Schema(example = "2025-09-01")
+    private LocalDate startDate;
+
+    @Schema(example = "2026-05-31")
+    private LocalDate endDate;
+
+    private AcademicYearStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/SemesterDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/SemesterDTO.java
@@ -1,0 +1,30 @@
+package com.schoolmanagement.dto;
+
+import com.schoolmanagement.entity.SemesterName;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Schema(description = "Học kỳ 1 (HK1) or Học kỳ 2 (HK2) within an academic year.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SemesterDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private Long academicYearId;
+    private String academicYearName;
+    private SemesterName name;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/SubjectDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/SubjectDTO.java
@@ -1,0 +1,34 @@
+package com.schoolmanagement.dto;
+
+import com.schoolmanagement.entity.SubjectCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Schema(description = "Môn học — a subject taught at one or more khối (grade levels).")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubjectDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+
+    @Schema(example = "TOAN")
+    private String code;
+
+    @Schema(example = "Toán học")
+    private String name;
+
+    @Schema(description = "CSV of applicable khối 6-12", example = "6,7,8,9,10,11,12")
+    private String gradeLevels;
+    private SubjectCategory category;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/AcademicYear.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/AcademicYear.java
@@ -1,0 +1,63 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "academic_years")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AcademicYear {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** e.g. "2025-2026" — a Vietnamese school year spans Sep -> May of the next calendar year. */
+    @NotBlank
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    @NotNull
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @NotNull
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private AcademicYearStatus status = AcademicYearStatus.ACTIVE;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @AssertTrue(message = "endDate must be after startDate")
+    public boolean isDateRangeValid() {
+        return startDate == null || endDate == null || endDate.isAfter(startDate);
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/AcademicYearStatus.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/AcademicYearStatus.java
@@ -1,0 +1,6 @@
+package com.schoolmanagement.entity;
+
+public enum AcademicYearStatus {
+    ACTIVE,
+    CLOSED
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/SchoolClass.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/SchoolClass.java
@@ -1,6 +1,8 @@
 package com.schoolmanagement.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
@@ -42,9 +44,28 @@ public class SchoolClass {
     @JoinColumn(name = "class_teacher_id")
     private Staff classTeacher;
 
+    /**
+     * @deprecated free-text academic year label, e.g. "2024-2025". Superseded by
+     * {@link #academicYearRef}, kept (and still required) so Phase 1-2 code and
+     * existing rows keep working during the transition — see Phase 3.1 migration
+     * (V3__academic_structure.sql), which backfills {@link #academicYearRef} from
+     * this column for every existing class.
+     */
+    @Deprecated
     @NotBlank
     @Column(name = "academic_year", nullable = false)
     private String academicYear;
+
+    /** The real academic year reference — set this on new/updated classes going forward. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "academic_year_id")
+    private AcademicYear academicYearRef;
+
+    /** Khối 6-12 (THCS: 6-9, THPT: 10-12). Optional during the transition — see academicYearRef. */
+    @Min(6)
+    @Max(12)
+    @Column(name = "grade_level")
+    private Integer gradeLevel;
 
     @Column(name = "room_number")
     private String roomNumber;

--- a/backend/src/main/java/com/schoolmanagement/entity/Semester.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/Semester.java
@@ -1,0 +1,64 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "semesters", uniqueConstraints = @UniqueConstraint(
+        name = "uk_semesters_year_name",
+        columnNames = {"academic_year_id", "name"}))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Semester {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "academic_year_id", nullable = false)
+    private AcademicYear academicYear;
+
+    /** HK1 (Học kỳ 1) / HK2 (Học kỳ 2) — not "Fall/Spring" or a US-style term. */
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SemesterName name;
+
+    @NotNull
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @NotNull
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @AssertTrue(message = "endDate must be after startDate")
+    public boolean isDateRangeValid() {
+        return startDate == null || endDate == null || endDate.isAfter(startDate);
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/SemesterName.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/SemesterName.java
@@ -1,0 +1,7 @@
+package com.schoolmanagement.entity;
+
+/** Học kỳ 1 / Học kỳ 2 — Vietnamese schools use two semesters per academic year, not quarters/trimesters. */
+public enum SemesterName {
+    HK1,
+    HK2
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/Student.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/Student.java
@@ -47,11 +47,26 @@ public class Student {
     @Column(name = "blood_group")
     private String bloodGroup;
 
+    /**
+     * @deprecated free-text class name, e.g. "10". Superseded by {@link #currentClass}
+     * (a real FK to {@link SchoolClass}), kept so Phase 1-2 code (class rosters are
+     * still matched by className+section) keeps working during the transition — see
+     * Phase 3.1 migration (V3__academic_structure.sql), which backfills
+     * {@link #currentClass} from this column + section for every existing student.
+     */
+    @Deprecated
     @Column(name = "class_name")
     private String className;
 
+    /** @deprecated see {@link #className}. */
+    @Deprecated
     @Column(name = "section")
     private String section;
+
+    /** The real current-class reference — set this on new/updated students going forward. */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "current_class_id")
+    private SchoolClass currentClass;
 
     @PastOrPresent
     @Column(name = "date_of_admission")

--- a/backend/src/main/java/com/schoolmanagement/entity/Subject.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/Subject.java
@@ -1,0 +1,60 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "subjects")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Subject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Short subject code, e.g. "TOAN", "VAN", "ANH". */
+    @NotBlank
+    @Column(unique = true, nullable = false)
+    private String code;
+
+    /** Full Vietnamese name, e.g. "Toán học". */
+    @NotBlank
+    @Column(nullable = false)
+    private String name;
+
+    /**
+     * CSV of applicable khối (grade levels 6-12), e.g. "6,7,8,9". Kept as a
+     * simple CSV column rather than a child table for now — normalize into a
+     * SubjectGradeLevel table later if per-grade-level queries are needed.
+     */
+    @Column(name = "grade_levels")
+    private String gradeLevels;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SubjectCategory category;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/SubjectCategory.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/SubjectCategory.java
@@ -1,0 +1,7 @@
+package com.schoolmanagement.entity;
+
+/** Bắt buộc (compulsory) vs. Tự chọn (elective). */
+public enum SubjectCategory {
+    BAT_BUOC,
+    TU_CHON
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/AcademicYearRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/AcademicYearRepository.java
@@ -1,0 +1,16 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.AcademicYearStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AcademicYearRepository extends JpaRepository<AcademicYear, Long> {
+    Optional<AcademicYear> findByName(String name);
+    boolean existsByName(String name);
+    List<AcademicYear> findByStatus(AcademicYearStatus status);
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/SchoolClassRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/SchoolClassRepository.java
@@ -1,5 +1,6 @@
 package com.schoolmanagement.repository;
 
+import com.schoolmanagement.entity.AcademicYear;
 import com.schoolmanagement.entity.SchoolClass;
 import com.schoolmanagement.entity.Staff;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,5 +16,6 @@ public interface SchoolClassRepository extends JpaRepository<SchoolClass, Long> 
     List<SchoolClass> findByAcademicYear(String academicYear);
     List<SchoolClass> findByClassName(String className);
     List<SchoolClass> findByClassTeacher(Staff classTeacher);
+    List<SchoolClass> findByAcademicYearRef(AcademicYear academicYearRef);
 }
 

--- a/backend/src/main/java/com/schoolmanagement/repository/SemesterRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/SemesterRepository.java
@@ -1,0 +1,16 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.SemesterName;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SemesterRepository extends JpaRepository<Semester, Long> {
+    List<Semester> findByAcademicYear(AcademicYear academicYear);
+    Optional<Semester> findByAcademicYearAndName(AcademicYear academicYear, SemesterName name);
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/SubjectRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/SubjectRepository.java
@@ -1,0 +1,13 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.Subject;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SubjectRepository extends JpaRepository<Subject, Long> {
+    Optional<Subject> findByCode(String code);
+    boolean existsByCode(String code);
+}

--- a/backend/src/main/java/com/schoolmanagement/service/AcademicYearService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/AcademicYearService.java
@@ -1,0 +1,97 @@
+package com.schoolmanagement.service;
+
+import com.schoolmanagement.dto.AcademicYearDTO;
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.AcademicYearStatus;
+import com.schoolmanagement.exception.DuplicateResourceException;
+import com.schoolmanagement.exception.ResourceInUseException;
+import com.schoolmanagement.exception.ResourceNotFoundException;
+import com.schoolmanagement.repository.AcademicYearRepository;
+import com.schoolmanagement.repository.SchoolClassRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class AcademicYearService {
+
+    private AcademicYearRepository academicYearRepository;
+    private SemesterRepository semesterRepository;
+    private SchoolClassRepository schoolClassRepository;
+
+    public AcademicYearDTO createAcademicYear(AcademicYear academicYear) {
+        if (academicYearRepository.existsByName(academicYear.getName())) {
+            throw new DuplicateResourceException("Academic year already exists: " + academicYear.getName());
+        }
+        return mapToDTO(academicYearRepository.save(academicYear));
+    }
+
+    public AcademicYearDTO updateAcademicYear(Long id, AcademicYear details) {
+        AcademicYear academicYear = academicYearRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Academic year not found with id: " + id));
+
+        if (!academicYear.getName().equals(details.getName())
+                && academicYearRepository.existsByName(details.getName())) {
+            throw new DuplicateResourceException("Academic year already exists: " + details.getName());
+        }
+
+        academicYear.setName(details.getName());
+        academicYear.setStartDate(details.getStartDate());
+        academicYear.setEndDate(details.getEndDate());
+        academicYear.setStatus(details.getStatus());
+
+        return mapToDTO(academicYearRepository.save(academicYear));
+    }
+
+    public AcademicYearDTO getAcademicYearById(Long id) {
+        return mapToDTO(academicYearRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Academic year not found with id: " + id)));
+    }
+
+    public List<AcademicYearDTO> getAllAcademicYears() {
+        return academicYearRepository.findAll()
+                .stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    /** Marks the academic year CLOSED — does not touch its classes/semesters/grades. */
+    public AcademicYearDTO closeAcademicYear(Long id) {
+        AcademicYear academicYear = academicYearRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Academic year not found with id: " + id));
+        academicYear.setStatus(AcademicYearStatus.CLOSED);
+        return mapToDTO(academicYearRepository.save(academicYear));
+    }
+
+    public void deleteAcademicYear(Long id) {
+        AcademicYear academicYear = academicYearRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Academic year not found with id: " + id));
+
+        if (!semesterRepository.findByAcademicYear(academicYear).isEmpty()) {
+            throw new ResourceInUseException("Cannot delete academic year: it still has semesters");
+        }
+        if (!schoolClassRepository.findByAcademicYearRef(academicYear).isEmpty()) {
+            throw new ResourceInUseException("Cannot delete academic year: it still has classes assigned to it");
+        }
+
+        academicYearRepository.delete(academicYear);
+    }
+
+    private AcademicYearDTO mapToDTO(AcademicYear academicYear) {
+        return AcademicYearDTO.builder()
+                .id(academicYear.getId())
+                .name(academicYear.getName())
+                .startDate(academicYear.getStartDate())
+                .endDate(academicYear.getEndDate())
+                .status(academicYear.getStatus())
+                .createdAt(academicYear.getCreatedAt())
+                .updatedAt(academicYear.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/service/SemesterService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/SemesterService.java
@@ -1,0 +1,112 @@
+package com.schoolmanagement.service;
+
+import com.schoolmanagement.dto.SemesterDTO;
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.exception.DuplicateResourceException;
+import com.schoolmanagement.exception.ResourceNotFoundException;
+import com.schoolmanagement.repository.AcademicYearRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class SemesterService {
+
+    private SemesterRepository semesterRepository;
+    private AcademicYearRepository academicYearRepository;
+
+    public SemesterDTO createSemester(Semester semester) {
+        AcademicYear academicYear = resolveAcademicYear(semester.getAcademicYear());
+        semester.setAcademicYear(academicYear);
+
+        semesterRepository.findByAcademicYearAndName(academicYear, semester.getName())
+                .ifPresent(existing -> {
+                    throw new DuplicateResourceException(
+                            "Semester " + semester.getName() + " already exists for " + academicYear.getName());
+                });
+
+        return mapToDTO(semesterRepository.save(semester));
+    }
+
+    public SemesterDTO updateSemester(Long id, Semester details) {
+        Semester semester = semesterRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Semester not found with id: " + id));
+
+        AcademicYear academicYear = resolveAcademicYear(details.getAcademicYear());
+
+        boolean changingKey = !semester.getAcademicYear().getId().equals(academicYear.getId())
+                || semester.getName() != details.getName();
+        if (changingKey) {
+            semesterRepository.findByAcademicYearAndName(academicYear, details.getName())
+                    .filter(existing -> !existing.getId().equals(id))
+                    .ifPresent(existing -> {
+                        throw new DuplicateResourceException(
+                                "Semester " + details.getName() + " already exists for " + academicYear.getName());
+                    });
+        }
+
+        semester.setAcademicYear(academicYear);
+        semester.setName(details.getName());
+        semester.setStartDate(details.getStartDate());
+        semester.setEndDate(details.getEndDate());
+
+        return mapToDTO(semesterRepository.save(semester));
+    }
+
+    public SemesterDTO getSemesterById(Long id) {
+        return mapToDTO(semesterRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Semester not found with id: " + id)));
+    }
+
+    public List<SemesterDTO> getAllSemesters() {
+        return semesterRepository.findAll()
+                .stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    public List<SemesterDTO> getSemestersByAcademicYear(Long academicYearId) {
+        AcademicYear academicYear = academicYearRepository.findById(academicYearId)
+                .orElseThrow(() -> new ResourceNotFoundException("Academic year not found with id: " + academicYearId));
+        return semesterRepository.findByAcademicYear(academicYear)
+                .stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    public void deleteSemester(Long id) {
+        Semester semester = semesterRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Semester not found with id: " + id));
+        semesterRepository.delete(semester);
+    }
+
+    private AcademicYear resolveAcademicYear(AcademicYear reference) {
+        if (reference == null || reference.getId() == null) {
+            throw new ResourceNotFoundException("An academic year id is required");
+        }
+        return academicYearRepository.findById(reference.getId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Academic year not found with id: " + reference.getId()));
+    }
+
+    private SemesterDTO mapToDTO(Semester semester) {
+        AcademicYear academicYear = semester.getAcademicYear();
+        return SemesterDTO.builder()
+                .id(semester.getId())
+                .academicYearId(academicYear != null ? academicYear.getId() : null)
+                .academicYearName(academicYear != null ? academicYear.getName() : null)
+                .name(semester.getName())
+                .startDate(semester.getStartDate())
+                .endDate(semester.getEndDate())
+                .createdAt(semester.getCreatedAt())
+                .updatedAt(semester.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/service/SubjectService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/SubjectService.java
@@ -1,0 +1,74 @@
+package com.schoolmanagement.service;
+
+import com.schoolmanagement.dto.SubjectDTO;
+import com.schoolmanagement.entity.Subject;
+import com.schoolmanagement.exception.DuplicateResourceException;
+import com.schoolmanagement.exception.ResourceNotFoundException;
+import com.schoolmanagement.repository.SubjectRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class SubjectService {
+
+    private SubjectRepository subjectRepository;
+
+    public SubjectDTO createSubject(Subject subject) {
+        if (subjectRepository.existsByCode(subject.getCode())) {
+            throw new DuplicateResourceException("Subject code already exists: " + subject.getCode());
+        }
+        return mapToDTO(subjectRepository.save(subject));
+    }
+
+    public SubjectDTO updateSubject(Long id, Subject details) {
+        Subject subject = subjectRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Subject not found with id: " + id));
+
+        if (!subject.getCode().equals(details.getCode()) && subjectRepository.existsByCode(details.getCode())) {
+            throw new DuplicateResourceException("Subject code already exists: " + details.getCode());
+        }
+
+        subject.setCode(details.getCode());
+        subject.setName(details.getName());
+        subject.setGradeLevels(details.getGradeLevels());
+        subject.setCategory(details.getCategory());
+
+        return mapToDTO(subjectRepository.save(subject));
+    }
+
+    public SubjectDTO getSubjectById(Long id) {
+        return mapToDTO(subjectRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Subject not found with id: " + id)));
+    }
+
+    public List<SubjectDTO> getAllSubjects() {
+        return subjectRepository.findAll()
+                .stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    public void deleteSubject(Long id) {
+        Subject subject = subjectRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Subject not found with id: " + id));
+        subjectRepository.delete(subject);
+    }
+
+    private SubjectDTO mapToDTO(Subject subject) {
+        return SubjectDTO.builder()
+                .id(subject.getId())
+                .code(subject.getCode())
+                .name(subject.getName())
+                .gradeLevels(subject.getGradeLevels())
+                .category(subject.getCategory())
+                .createdAt(subject.getCreatedAt())
+                .updatedAt(subject.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/resources/db/migration/V3__academic_structure.sql
+++ b/backend/src/main/resources/db/migration/V3__academic_structure.sql
@@ -1,0 +1,120 @@
+-- =====================================================
+-- Phase 3.1: Academic Year / Semester / Subject
+-- =====================================================
+-- New tables, plus backfill of the FK columns added to `classes` and
+-- `students` (academic_year_id/grade_level, current_class_id) from the
+-- free-text data that already exists. The old free-text columns
+-- (classes.academic_year, students.class_name/section) are kept —
+-- @Deprecated on the entities, not dropped here — so nothing already
+-- shipped in Phase 1-2 breaks. See KẾ HOẠCH MIGRATION DỮ LIỆU in
+-- IMPLEMENTATION_PLAN.md.
+-- =====================================================
+
+CREATE TABLE `academic_years` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `start_date` date NOT NULL,
+  `end_date` date NOT NULL,
+  `status` enum('ACTIVE','CLOSED') NOT NULL,
+  `created_at` datetime(6) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_academic_years_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `semesters` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `academic_year_id` bigint NOT NULL,
+  `name` enum('HK1','HK2') NOT NULL,
+  `start_date` date NOT NULL,
+  `end_date` date NOT NULL,
+  `created_at` datetime(6) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_semesters_year_name` (`academic_year_id`, `name`),
+  CONSTRAINT `fk_semesters_academic_year` FOREIGN KEY (`academic_year_id`) REFERENCES `academic_years` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `subjects` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `code` varchar(255) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `grade_levels` varchar(255) DEFAULT NULL,
+  `category` enum('BAT_BUOC','TU_CHON') NOT NULL,
+  `created_at` datetime(6) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_subjects_code` (`code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- New FK columns on existing tables (old free-text columns untouched)
+ALTER TABLE `classes`
+  ADD COLUMN `academic_year_id` bigint DEFAULT NULL AFTER `academic_year`,
+  ADD COLUMN `grade_level` int DEFAULT NULL AFTER `academic_year_id`,
+  ADD CONSTRAINT `fk_classes_academic_year` FOREIGN KEY (`academic_year_id`) REFERENCES `academic_years` (`id`);
+
+ALTER TABLE `students`
+  ADD COLUMN `current_class_id` bigint DEFAULT NULL AFTER `section`,
+  ADD CONSTRAINT `fk_students_current_class` FOREIGN KEY (`current_class_id`) REFERENCES `classes` (`id`);
+
+-- =====================================================
+-- Backfill: AcademicYear, derived from every distinct "YYYY-YYYY" label
+-- already used in classes/grades/fees. Vietnamese school year ~ Sep -> May.
+-- =====================================================
+INSERT INTO academic_years (name, start_date, end_date, status, created_at, updated_at)
+SELECT DISTINCT
+  y.label,
+  STR_TO_DATE(CONCAT(SUBSTRING_INDEX(y.label, '-', 1), '-09-01'), '%Y-%m-%d'),
+  STR_TO_DATE(CONCAT(SUBSTRING_INDEX(y.label, '-', -1), '-05-31'), '%Y-%m-%d'),
+  'ACTIVE',
+  NOW(6),
+  NOW(6)
+FROM (
+  SELECT academic_year AS label FROM classes WHERE academic_year REGEXP '^[0-9]{4}-[0-9]{4}$'
+  UNION
+  SELECT academic_year FROM grades WHERE academic_year REGEXP '^[0-9]{4}-[0-9]{4}$'
+  UNION
+  SELECT academic_year FROM fees WHERE academic_year REGEXP '^[0-9]{4}-[0-9]{4}$'
+) y;
+
+-- Backfill: one HK1 semester per academic year as a starting point (plan:
+-- "mặc định Học kỳ 1, cho phép sửa lại thủ công" — an admin can add HK2 and
+-- adjust dates via /v1/semesters afterwards).
+INSERT INTO semesters (academic_year_id, name, start_date, end_date, created_at, updated_at)
+SELECT id, 'HK1', start_date, end_date, NOW(6), NOW(6)
+FROM academic_years;
+
+-- Backfill: Subject, derived from every distinct grades.subject value.
+-- code is a best-effort slug (upper-case, spaces -> underscores, truncated to
+-- fit); duplicates after truncation are silently skipped (INSERT IGNORE) —
+-- review/rename via PUT /v1/subjects/{id} afterwards.
+INSERT IGNORE INTO subjects (code, name, category, created_at, updated_at)
+SELECT DISTINCT
+  UPPER(LEFT(REPLACE(TRIM(subject), ' ', '_'), 50)),
+  subject,
+  'BAT_BUOC',
+  NOW(6),
+  NOW(6)
+FROM grades
+WHERE subject IS NOT NULL AND subject != '';
+
+-- Backfill classes.academic_year_id from the matching academic_years row.
+UPDATE classes c
+JOIN academic_years ay ON ay.name = c.academic_year
+SET c.academic_year_id = ay.id;
+
+-- Backfill classes.grade_level where class_name is a plain 6-12 number
+-- (e.g. "10"); non-numeric class names are left NULL for manual review.
+UPDATE classes
+SET grade_level = CAST(class_name AS UNSIGNED)
+WHERE class_name REGEXP '^[0-9]+$'
+  AND CAST(class_name AS UNSIGNED) BETWEEN 6 AND 12;
+
+-- Backfill students.current_class_id by matching the old free-text
+-- class_name+section to a class. If the same class_name+section exists in
+-- more than one academic year, MySQL picks one match arbitrarily — fine for
+-- the current single-academic-year dataset; review manually otherwise.
+UPDATE students s
+JOIN classes c ON c.class_name = s.class_name AND c.section = s.section
+SET s.current_class_id = c.id
+WHERE s.class_name IS NOT NULL AND s.section IS NOT NULL;

--- a/backend/src/test/java/com/schoolmanagement/controller/AcademicStructureIntegrationTest.java
+++ b/backend/src/test/java/com/schoolmanagement/controller/AcademicStructureIntegrationTest.java
@@ -1,0 +1,221 @@
+package com.schoolmanagement.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.AcademicYearStatus;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.SemesterName;
+import com.schoolmanagement.entity.Subject;
+import com.schoolmanagement.entity.SubjectCategory;
+import com.schoolmanagement.repository.AcademicYearRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import com.schoolmanagement.repository.SubjectRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration test for /v1/academic-years, /v1/semesters, /v1/subjects —
+ * real Spring context + local MySQL via the "test" profile. Each test rolls
+ * back (@Transactional), so it never depends on — or pollutes — the
+ * migration-backfilled 2024-2025 academic year / HK1 / subjects.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AcademicStructureIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private AcademicYearRepository academicYearRepository;
+    @Autowired
+    private SemesterRepository semesterRepository;
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    private AcademicYear newYear(String name) {
+        return AcademicYear.builder()
+                .name(name)
+                .startDate(LocalDate.of(2030, 9, 1))
+                .endDate(LocalDate.of(2031, 5, 31))
+                .status(AcademicYearStatus.ACTIVE)
+                .build();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createAcademicYear_persistsAndReturnsIt() throws Exception {
+        mockMvc.perform(post("/v1/academic-years")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newYear("ITEST-2030-2031"))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("ITEST-2030-2031"))
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createAcademicYear_duplicateName_returns409() throws Exception {
+        academicYearRepository.save(newYear("ITEST-DUP"));
+
+        mockMvc.perform(post("/v1/academic-years")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newYear("ITEST-DUP"))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createAcademicYear_endDateBeforeStartDate_returns400() throws Exception {
+        AcademicYear invalid = AcademicYear.builder()
+                .name("ITEST-BAD-RANGE")
+                .startDate(LocalDate.of(2030, 9, 1))
+                .endDate(LocalDate.of(2020, 5, 31))
+                .build();
+
+        mockMvc.perform(post("/v1/academic-years")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "TEACHER")
+    void createAcademicYear_asTeacher_returns403() throws Exception {
+        mockMvc.perform(post("/v1/academic-years")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newYear("ITEST-RBAC"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void closeAcademicYear_setsStatusClosed() throws Exception {
+        AcademicYear saved = academicYearRepository.save(newYear("ITEST-CLOSE"));
+
+        mockMvc.perform(put("/v1/academic-years/{id}/close", saved.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CLOSED"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteAcademicYear_withSemesters_returns409() throws Exception {
+        AcademicYear saved = academicYearRepository.save(newYear("ITEST-INUSE"));
+        semesterRepository.save(Semester.builder()
+                .academicYear(saved)
+                .name(SemesterName.HK1)
+                .startDate(saved.getStartDate())
+                .endDate(saved.getEndDate())
+                .build());
+
+        mockMvc.perform(delete("/v1/academic-years/{id}", saved.getId()))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteAcademicYear_empty_returns204() throws Exception {
+        AcademicYear saved = academicYearRepository.save(newYear("ITEST-EMPTY"));
+
+        mockMvc.perform(delete("/v1/academic-years/{id}", saved.getId()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSemester_forExistingAcademicYear_persists() throws Exception {
+        AcademicYear saved = academicYearRepository.save(newYear("ITEST-SEM"));
+        Semester semester = Semester.builder()
+                .academicYear(AcademicYear.builder().id(saved.getId()).build())
+                .name(SemesterName.HK1)
+                .startDate(saved.getStartDate())
+                .endDate(saved.getEndDate())
+                .build();
+
+        mockMvc.perform(post("/v1/semesters")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(semester)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.academicYearId").value(saved.getId()))
+                .andExpect(jsonPath("$.name").value("HK1"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSemester_duplicateNameForSameYear_returns409() throws Exception {
+        AcademicYear saved = academicYearRepository.save(newYear("ITEST-SEM-DUP"));
+        semesterRepository.save(Semester.builder()
+                .academicYear(saved)
+                .name(SemesterName.HK1)
+                .startDate(saved.getStartDate())
+                .endDate(saved.getEndDate())
+                .build());
+
+        Semester duplicate = Semester.builder()
+                .academicYear(AcademicYear.builder().id(saved.getId()).build())
+                .name(SemesterName.HK1)
+                .startDate(saved.getStartDate())
+                .endDate(saved.getEndDate())
+                .build();
+
+        mockMvc.perform(post("/v1/semesters")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(duplicate)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSubject_persistsAndReturnsIt() throws Exception {
+        Subject subject = Subject.builder()
+                .code("ITEST-LY")
+                .name("Vật lý")
+                .gradeLevels("10,11,12")
+                .category(SubjectCategory.BAT_BUOC)
+                .build();
+
+        mockMvc.perform(post("/v1/subjects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(subject)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.code").value("ITEST-LY"))
+                .andExpect(jsonPath("$.name").value("Vật lý"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSubject_duplicateCode_returns409() throws Exception {
+        subjectRepository.save(Subject.builder()
+                .code("ITEST-HOA")
+                .name("Hoá học")
+                .category(SubjectCategory.BAT_BUOC)
+                .build());
+
+        Subject duplicate = Subject.builder()
+                .code("ITEST-HOA")
+                .name("Hoá học (khác)")
+                .category(SubjectCategory.TU_CHON)
+                .build();
+
+        mockMvc.perform(post("/v1/subjects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(duplicate)))
+                .andExpect(status().isConflict());
+    }
+}


### PR DESCRIPTION
New entities + CRUD per IMPLEMENTATION_PLAN.md 3.1, following the Vietnamese-education cross-cutting principle (HK1/HK2 not Fall/Spring, Sep->May school year, khối 6-12):

- entity/AcademicYear.java: name (unique, e.g. "2025-2026"), startDate/endDate (@AssertTrue endDate > startDate), status (ACTIVE/CLOSED).
- entity/Semester.java: FK to AcademicYear, name (HK1/HK2, unique per year), startDate/endDate.
- entity/Subject.java: code (unique, e.g. "TOAN"), name (e.g. "Toán học"), gradeLevels (CSV of khối), category (BAT_BUOC/TU_CHON).
- Repositories, DTOs (with @Schema), services (duplicate/date-range/ in-use checks -> 409/400/409), controllers: POST/PUT/GET/DELETE for all three + PUT /v1/academic-years/{id}/close, ADMIN/PRINCIPAL for writes, +TEACHER for reads — matching the endpoint table in the plan.

SchoolClass.academicYear (String) and Student.className/section keep working exactly as before — marked @Deprecated rather than removed, so none of Phase 1-2's already-shipped code or tests break. New relational fields added alongside them: SchoolClass.academicYearRef (FK) + gradeLevel (6-12), Student.currentClass (FK to SchoolClass). New code should read/write the FK fields going forward.

db/migration/V3__academic_structure.sql: creates the three tables, adds academic_year_id/grade_level to classes and current_class_id to students, then backfills all of it from the existing free-text data — AcademicYear from every distinct "YYYY-YYYY" label across classes/ grades/fees (Sep 1 -> May 31 dates), one default HK1 semester per academic year, Subject from every distinct grades.subject value, classes.academic_year_id/grade_level and students.current_class_id matched from the old string columns.

Add AcademicStructureIntegrationTest (11 cases, real Spring context + local MySQL, @Transactional rollback): create/duplicate/date-range- validation/RBAC for academic years, close, delete blocked with semesters vs. allowed empty, semester create + duplicate-per-year rejection, subject create + duplicate-code rejection.

Verified live against local MySQL: migration backfilled correctly (1 academic year "2024-2025" with Sep/May dates, 1 HK1 semester, 3 subjects from seeded grades, all 4 classes' academic_year_id/ grade_level and all 6 students' current_class_id populated correctly). Also verified Vietnamese diacritics round-trip correctly end-to-end (create Subject "Toán học" via a real UTF-8 payload — confirmed stored correctly in MySQL and returned correctly in the JSON response; an earlier 500 turned out to be a Git-Bash-on-Windows shell-arg encoding artifact in my own curl test, not an application bug). Full `mvn test` suite passes (29/29: 1 context + 11 academic-structure + 10 class + 1 exception-handler + 6 auth).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added management of academic years, including creation, updates, closure, retrieval, and deletion.
  * Added semester management with academic-year filtering and validation.
  * Added subject management with categorization, grade levels, and unique codes.
  * Connected classes and students to the new academic structure while retaining legacy information during transition.
* **Documentation**
  * Updated documentation to describe the academic structure and completed roadmap items.
* **Tests**
  * Added coverage for validation, permissions, associations, uniqueness, and lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->