### PR TITLE
Phase 3.2: Teaching assignments (phân công giảng dạy) + Timetable

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -38,6 +38,8 @@ http://localhost:8080/api/swagger-ui.html
 | Academic Years | `/v1/academic-years/*` | Năm học CRUD + close |
 | Semesters | `/v1/semesters/*` | Học kỳ (HK1/HK2) CRUD |
 | Subjects | `/v1/subjects/*` | Môn học CRUD |
+| Teaching Assignments | `/v1/teaching-assignments/*` | Phân công giảng dạy (teacher × subject × class × semester) |
+| Timetable | `/v1/timetable/*` | Thời khoá biểu — class/teacher schedule, slot CRUD with teacher/room/class conflict checks |
 | Attendance | `/v1/attendance/*` | Daily attendance |
 | Grades | `/v1/grades/*` | Assessments |
 | Fees | `/v1/fees/*` | Student fees & payments |
@@ -51,6 +53,7 @@ See [Swagger UI](http://localhost:8080/api/swagger-ui.html) for the full, curren
 - **MySQL 8.0**, local. Charset **`utf8mb4`** / collation **`utf8mb4_unicode_ci`** is required (plain `utf8` only supports 3-byte characters and mangles Vietnamese diacritics).
 - Schema is managed by **Flyway** (`src/main/resources/db/migration/`) — `ddl-auto` is `validate`, never `update`. To change the schema, add a new `V{n}__description.sql` migration; don't hand-edit the DB or rely on Hibernate to create tables.
 - `V3__academic_structure.sql` added `AcademicYear`/`Semester`/`Subject` and backfilled them from the old free-text data (`classes.academic_year`, `grades.subject`). The old columns this replaces (`SchoolClass.academicYear` String, `Student.className`/`section`) are kept and marked `@Deprecated` on the entity — not dropped — so nothing already built against them breaks; new code should read/write `SchoolClass.academicYearRef` and `Student.currentClass` instead.
+- `V4__teaching_timetable.sql` added `TeachingAssignment`/`TimetableSlot` (no backfill — nothing pre-3.2 represented this data).
 - Create the database once:
   ```sql
   CREATE DATABASE school_management CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -178,4 +181,4 @@ backend/
 
 ## 🚀 Future enhancements
 
-See the "Giai đoạn 3" section of [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) for the full roadmap — Thông tư 22/58 grading & xếp loại học lực, hạnh kiểm, phân công giảng dạy & thời khoá biểu, promotion workflow, parent portal & sổ liên lạc điện tử, admissions, PDF/Excel reports, audit log. (Năm học/Học kỳ/Môn học — 3.1 — is done, above.)
+See the "Giai đoạn 3" section of [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) for the full roadmap — Thông tư 22/58 grading & xếp loại học lực, hạnh kiểm, promotion workflow, parent portal & sổ liên lạc điện tử, admissions, PDF/Excel reports, audit log. (3.1 Năm học/Học kỳ/Môn học and 3.2 Phân công giảng dạy & Thời khoá biểu are done, above.)

--- a/backend/src/main/java/com/schoolmanagement/controller/TeachingAssignmentController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/TeachingAssignmentController.java
@@ -1,0 +1,61 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.dto.TeachingAssignmentDTO;
+import com.schoolmanagement.entity.TeachingAssignment;
+import com.schoolmanagement.service.TeachingAssignmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/teaching-assignments")
+@AllArgsConstructor
+@Tag(name = "Teaching Assignments", description = "Phân công giảng dạy — which teacher teaches which subject to which class")
+public class TeachingAssignmentController {
+
+    private TeachingAssignmentService teachingAssignmentService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Create teaching assignment")
+    public ResponseEntity<TeachingAssignmentDTO> createTeachingAssignment(@Valid @RequestBody TeachingAssignment request) {
+        return new ResponseEntity<>(teachingAssignmentService.createTeachingAssignment(request), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Update teaching assignment")
+    public ResponseEntity<TeachingAssignmentDTO> updateTeachingAssignment(
+            @PathVariable Long id, @Valid @RequestBody TeachingAssignment request) {
+        return new ResponseEntity<>(teachingAssignmentService.updateTeachingAssignment(id, request), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get teaching assignment by ID")
+    public ResponseEntity<TeachingAssignmentDTO> getTeachingAssignmentById(@PathVariable Long id) {
+        return new ResponseEntity<>(teachingAssignmentService.getTeachingAssignmentById(id), HttpStatus.OK);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get all teaching assignments")
+    public ResponseEntity<List<TeachingAssignmentDTO>> getAllTeachingAssignments() {
+        return new ResponseEntity<>(teachingAssignmentService.getAllTeachingAssignments(), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Delete teaching assignment", description = "Refused with 409 if it still has timetable slots scheduled.")
+    public ResponseEntity<Void> deleteTeachingAssignment(@PathVariable Long id) {
+        teachingAssignmentService.deleteTeachingAssignment(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/controller/TimetableController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/TimetableController.java
@@ -1,0 +1,67 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.dto.TimetableSlotDTO;
+import com.schoolmanagement.entity.TimetableSlot;
+import com.schoolmanagement.service.TimetableService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/timetable")
+@AllArgsConstructor
+@Tag(name = "Timetable", description = "Thời khoá biểu — weekly schedule slots")
+public class TimetableController {
+
+    private TimetableService timetableService;
+
+    @GetMapping("/class/{classId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get a class's weekly timetable",
+            description = "Optional semesterId query param filters to one semester; omit to get every slot ever scheduled for the class.")
+    public ResponseEntity<List<TimetableSlotDTO>> getClassTimetable(
+            @PathVariable Long classId,
+            @RequestParam(required = false) Long semesterId) {
+        return new ResponseEntity<>(timetableService.getClassTimetable(classId, semesterId), HttpStatus.OK);
+    }
+
+    @GetMapping("/teacher/{teacherId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Get a teacher's weekly timetable",
+            description = "Optional semesterId query param filters to one semester; omit to get every slot ever scheduled for the teacher.")
+    public ResponseEntity<List<TimetableSlotDTO>> getTeacherTimetable(
+            @PathVariable Long teacherId,
+            @RequestParam(required = false) Long semesterId) {
+        return new ResponseEntity<>(timetableService.getTeacherTimetable(teacherId, semesterId), HttpStatus.OK);
+    }
+
+    @PostMapping("/slots")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Create a timetable slot",
+            description = "Refused with 409 if the teacher, room, or class already has a slot at that day/period in the same semester.")
+    public ResponseEntity<TimetableSlotDTO> createSlot(@Valid @RequestBody TimetableSlot request) {
+        return new ResponseEntity<>(timetableService.createSlot(request), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/slots/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Update a timetable slot", description = "Same conflict checks as create, excluding this slot itself.")
+    public ResponseEntity<TimetableSlotDTO> updateSlot(@PathVariable Long id, @Valid @RequestBody TimetableSlot request) {
+        return new ResponseEntity<>(timetableService.updateSlot(id, request), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/slots/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Delete a timetable slot")
+    public ResponseEntity<Void> deleteSlot(@PathVariable Long id) {
+        timetableService.deleteSlot(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/TeachingAssignmentDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/TeachingAssignmentDTO.java
@@ -1,0 +1,34 @@
+package com.schoolmanagement.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Schema(description = "Phân công giảng dạy — which teacher teaches which subject to which class, for one semester.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TeachingAssignmentDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private Long schoolClassId;
+
+    @Schema(example = "10-A")
+    private String schoolClassLabel;
+    private Long subjectId;
+    private String subjectCode;
+    private String subjectName;
+    private Long teacherId;
+    private String teacherName;
+    private Long semesterId;
+    private String semesterLabel;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/TimetableSlotDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/TimetableSlotDTO.java
@@ -1,0 +1,42 @@
+package com.schoolmanagement.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Schema(description = "One weekly-recurring period on the thời khoá biểu (timetable).")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TimetableSlotDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private Long teachingAssignmentId;
+    private Long schoolClassId;
+
+    @Schema(example = "10-A")
+    private String schoolClassLabel;
+
+    private Long subjectId;
+    private String subjectName;
+    private Long teacherId;
+    private String teacherName;
+
+    @Schema(description = "Thứ Hai (Monday) = 2 ... Thứ Bảy (Saturday) = 7", example = "2")
+    private Integer dayOfWeek;
+
+    @Schema(description = "Tiết học trong ngày, 1-10", example = "1")
+    private Integer period;
+
+    @Schema(example = "P.101")
+    private String room;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/TeachingAssignment.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/TeachingAssignment.java
@@ -1,0 +1,59 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/** Phân công giảng dạy — which teacher teaches which subject to which class, in which semester. */
+@Entity
+@Table(name = "teaching_assignments", uniqueConstraints = @UniqueConstraint(
+        name = "uk_teaching_assignment_class_subject_semester",
+        columnNames = {"school_class_id", "subject_id", "semester_id"}))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TeachingAssignment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "school_class_id", nullable = false)
+    private SchoolClass schoolClass;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subject_id", nullable = false)
+    private Subject subject;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "teacher_id", nullable = false)
+    private Staff teacher;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "semester_id", nullable = false)
+    private Semester semester;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/TimetableSlot.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/TimetableSlot.java
@@ -1,0 +1,67 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * One weekly-recurring period on the thời khoá biểu (timetable) for a
+ * {@link TeachingAssignment}. dayOfWeek follows the Vietnamese calendar
+ * convention: Thứ Hai (Monday) = 2 ... Thứ Bảy (Saturday) = 7 (no Sunday).
+ */
+@Entity
+@Table(name = "timetable_slots")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TimetableSlot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "teaching_assignment_id", nullable = false)
+    private TeachingAssignment teachingAssignment;
+
+    /** Thứ Hai (Monday) = 2 ... Thứ Bảy (Saturday) = 7. */
+    @NotNull
+    @Min(2)
+    @Max(7)
+    @Column(name = "day_of_week", nullable = false)
+    private Integer dayOfWeek;
+
+    /** Tiết học trong ngày, 1-10 (buổi sáng + buổi chiều). */
+    @NotNull
+    @Min(1)
+    @Max(10)
+    @Column(nullable = false)
+    private Integer period;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String room;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/schoolmanagement/exception/GlobalExceptionHandler.java
@@ -61,6 +61,20 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(error, HttpStatus.CONFLICT);
     }
 
+    @ExceptionHandler(ScheduleConflictException.class)
+    public ResponseEntity<ApiError> handleScheduleConflictException(
+            ScheduleConflictException ex,
+            HttpServletRequest request) {
+        ApiError error = ApiError.builder()
+                .status("CONFLICT")
+                .message(ex.getMessage())
+                .code(409)
+                .path(request.getRequestURI())
+                .timestamp(LocalDateTime.now())
+                .build();
+        return new ResponseEntity<>(error, HttpStatus.CONFLICT);
+    }
+
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<ApiError> handleBadCredentialsException(
             BadCredentialsException ex,

--- a/backend/src/main/java/com/schoolmanagement/exception/ScheduleConflictException.java
+++ b/backend/src/main/java/com/schoolmanagement/exception/ScheduleConflictException.java
@@ -1,0 +1,11 @@
+package com.schoolmanagement.exception;
+
+/**
+ * Thrown when a timetable slot would double-book a teacher, room, or class —
+ * same semester, day of week, and period already taken by something else.
+ */
+public class ScheduleConflictException extends RuntimeException {
+    public ScheduleConflictException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/TeachingAssignmentRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/TeachingAssignmentRepository.java
@@ -1,0 +1,21 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.SchoolClass;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.Subject;
+import com.schoolmanagement.entity.TeachingAssignment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TeachingAssignmentRepository extends JpaRepository<TeachingAssignment, Long> {
+    List<TeachingAssignment> findBySchoolClass(SchoolClass schoolClass);
+    List<TeachingAssignment> findByTeacher(Staff teacher);
+    List<TeachingAssignment> findBySemester(Semester semester);
+    Optional<TeachingAssignment> findBySchoolClassAndSubjectAndSemester(
+            SchoolClass schoolClass, Subject subject, Semester semester);
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/TimetableSlotRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/TimetableSlotRepository.java
@@ -1,0 +1,60 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.SchoolClass;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.TeachingAssignment;
+import com.schoolmanagement.entity.TimetableSlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TimetableSlotRepository extends JpaRepository<TimetableSlot, Long> {
+    List<TimetableSlot> findByTeachingAssignment(TeachingAssignment teachingAssignment);
+    List<TimetableSlot> findByTeachingAssignment_SchoolClass(SchoolClass schoolClass);
+    List<TimetableSlot> findByTeachingAssignment_SchoolClassAndTeachingAssignment_Semester(
+            SchoolClass schoolClass, Semester semester);
+    List<TimetableSlot> findByTeachingAssignment_Teacher(Staff teacher);
+    List<TimetableSlot> findByTeachingAssignment_TeacherAndTeachingAssignment_Semester(
+            Staff teacher, Semester semester);
+
+    /** True if this teacher already has a slot at the same day/period within the same semester. */
+    @Query("SELECT COUNT(ts) > 0 FROM TimetableSlot ts " +
+            "WHERE ts.teachingAssignment.teacher.id = :teacherId " +
+            "AND ts.teachingAssignment.semester.id = :semesterId " +
+            "AND ts.dayOfWeek = :dayOfWeek AND ts.period = :period " +
+            "AND (:excludeSlotId IS NULL OR ts.id <> :excludeSlotId)")
+    boolean existsTeacherConflict(@Param("teacherId") Long teacherId,
+                                   @Param("semesterId") Long semesterId,
+                                   @Param("dayOfWeek") Integer dayOfWeek,
+                                   @Param("period") Integer period,
+                                   @Param("excludeSlotId") Long excludeSlotId);
+
+    /** True if this room is already booked at the same day/period within the same semester. */
+    @Query("SELECT COUNT(ts) > 0 FROM TimetableSlot ts " +
+            "WHERE ts.room = :room " +
+            "AND ts.teachingAssignment.semester.id = :semesterId " +
+            "AND ts.dayOfWeek = :dayOfWeek AND ts.period = :period " +
+            "AND (:excludeSlotId IS NULL OR ts.id <> :excludeSlotId)")
+    boolean existsRoomConflict(@Param("room") String room,
+                                @Param("semesterId") Long semesterId,
+                                @Param("dayOfWeek") Integer dayOfWeek,
+                                @Param("period") Integer period,
+                                @Param("excludeSlotId") Long excludeSlotId);
+
+    /** True if this class already has a slot at the same day/period within the same semester. */
+    @Query("SELECT COUNT(ts) > 0 FROM TimetableSlot ts " +
+            "WHERE ts.teachingAssignment.schoolClass.id = :schoolClassId " +
+            "AND ts.teachingAssignment.semester.id = :semesterId " +
+            "AND ts.dayOfWeek = :dayOfWeek AND ts.period = :period " +
+            "AND (:excludeSlotId IS NULL OR ts.id <> :excludeSlotId)")
+    boolean existsClassConflict(@Param("schoolClassId") Long schoolClassId,
+                                 @Param("semesterId") Long semesterId,
+                                 @Param("dayOfWeek") Integer dayOfWeek,
+                                 @Param("period") Integer period,
+                                 @Param("excludeSlotId") Long excludeSlotId);
+}

--- a/backend/src/main/java/com/schoolmanagement/service/TeachingAssignmentService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/TeachingAssignmentService.java
@@ -1,0 +1,162 @@
+package com.schoolmanagement.service;
+
+import com.schoolmanagement.dto.TeachingAssignmentDTO;
+import com.schoolmanagement.entity.SchoolClass;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.Subject;
+import com.schoolmanagement.entity.TeachingAssignment;
+import com.schoolmanagement.exception.DuplicateResourceException;
+import com.schoolmanagement.exception.ResourceInUseException;
+import com.schoolmanagement.exception.ResourceNotFoundException;
+import com.schoolmanagement.repository.SchoolClassRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import com.schoolmanagement.repository.StaffRepository;
+import com.schoolmanagement.repository.SubjectRepository;
+import com.schoolmanagement.repository.TeachingAssignmentRepository;
+import com.schoolmanagement.repository.TimetableSlotRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class TeachingAssignmentService {
+
+    private TeachingAssignmentRepository teachingAssignmentRepository;
+    private TimetableSlotRepository timetableSlotRepository;
+    private SchoolClassRepository schoolClassRepository;
+    private SubjectRepository subjectRepository;
+    private StaffRepository staffRepository;
+    private SemesterRepository semesterRepository;
+
+    public TeachingAssignmentDTO createTeachingAssignment(TeachingAssignment request) {
+        SchoolClass schoolClass = resolveSchoolClass(request.getSchoolClass());
+        Subject subject = resolveSubject(request.getSubject());
+        Staff teacher = resolveTeacher(request.getTeacher());
+        Semester semester = resolveSemester(request.getSemester());
+
+        assertNoDuplicate(schoolClass, subject, semester, null);
+
+        TeachingAssignment assignment = TeachingAssignment.builder()
+                .schoolClass(schoolClass)
+                .subject(subject)
+                .teacher(teacher)
+                .semester(semester)
+                .build();
+
+        return mapToDTO(teachingAssignmentRepository.save(assignment));
+    }
+
+    public TeachingAssignmentDTO updateTeachingAssignment(Long id, TeachingAssignment request) {
+        TeachingAssignment assignment = teachingAssignmentRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Teaching assignment not found with id: " + id));
+
+        SchoolClass schoolClass = resolveSchoolClass(request.getSchoolClass());
+        Subject subject = resolveSubject(request.getSubject());
+        Staff teacher = resolveTeacher(request.getTeacher());
+        Semester semester = resolveSemester(request.getSemester());
+
+        assertNoDuplicate(schoolClass, subject, semester, id);
+
+        assignment.setSchoolClass(schoolClass);
+        assignment.setSubject(subject);
+        assignment.setTeacher(teacher);
+        assignment.setSemester(semester);
+
+        return mapToDTO(teachingAssignmentRepository.save(assignment));
+    }
+
+    public TeachingAssignmentDTO getTeachingAssignmentById(Long id) {
+        return mapToDTO(teachingAssignmentRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Teaching assignment not found with id: " + id)));
+    }
+
+    public List<TeachingAssignmentDTO> getAllTeachingAssignments() {
+        return teachingAssignmentRepository.findAll()
+                .stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    public void deleteTeachingAssignment(Long id) {
+        TeachingAssignment assignment = teachingAssignmentRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Teaching assignment not found with id: " + id));
+
+        if (!timetableSlotRepository.findByTeachingAssignment(assignment).isEmpty()) {
+            throw new ResourceInUseException(
+                    "Cannot delete teaching assignment: it still has timetable slots scheduled");
+        }
+
+        teachingAssignmentRepository.delete(assignment);
+    }
+
+    private void assertNoDuplicate(SchoolClass schoolClass, Subject subject, Semester semester, Long excludeId) {
+        teachingAssignmentRepository.findBySchoolClassAndSubjectAndSemester(schoolClass, subject, semester)
+                .filter(existing -> !existing.getId().equals(excludeId))
+                .ifPresent(existing -> {
+                    throw new DuplicateResourceException(
+                            "A teaching assignment for this class/subject/semester already exists");
+                });
+    }
+
+    private SchoolClass resolveSchoolClass(SchoolClass reference) {
+        if (reference == null || reference.getId() == null) {
+            throw new ResourceNotFoundException("A school class id is required");
+        }
+        return schoolClassRepository.findById(reference.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Class not found with id: " + reference.getId()));
+    }
+
+    private Subject resolveSubject(Subject reference) {
+        if (reference == null || reference.getId() == null) {
+            throw new ResourceNotFoundException("A subject id is required");
+        }
+        return subjectRepository.findById(reference.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Subject not found with id: " + reference.getId()));
+    }
+
+    private Staff resolveTeacher(Staff reference) {
+        if (reference == null || reference.getId() == null) {
+            throw new ResourceNotFoundException("A teacher (staff) id is required");
+        }
+        return staffRepository.findById(reference.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Staff not found with id: " + reference.getId()));
+    }
+
+    private Semester resolveSemester(Semester reference) {
+        if (reference == null || reference.getId() == null) {
+            throw new ResourceNotFoundException("A semester id is required");
+        }
+        return semesterRepository.findById(reference.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Semester not found with id: " + reference.getId()));
+    }
+
+    private TeachingAssignmentDTO mapToDTO(TeachingAssignment assignment) {
+        SchoolClass schoolClass = assignment.getSchoolClass();
+        Subject subject = assignment.getSubject();
+        Staff teacher = assignment.getTeacher();
+        Semester semester = assignment.getSemester();
+
+        return TeachingAssignmentDTO.builder()
+                .id(assignment.getId())
+                .schoolClassId(schoolClass.getId())
+                .schoolClassLabel(schoolClass.getClassName() + "-" + schoolClass.getSection())
+                .subjectId(subject.getId())
+                .subjectCode(subject.getCode())
+                .subjectName(subject.getName())
+                .teacherId(teacher.getId())
+                .teacherName(teacher.getUser() != null
+                        ? teacher.getUser().getFirstName() + " " + teacher.getUser().getLastName()
+                        : null)
+                .semesterId(semester.getId())
+                .semesterLabel(semester.getAcademicYear().getName() + " - " + semester.getName())
+                .createdAt(assignment.getCreatedAt())
+                .updatedAt(assignment.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/service/TimetableService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/TimetableService.java
@@ -1,0 +1,146 @@
+package com.schoolmanagement.service;
+
+import com.schoolmanagement.dto.TimetableSlotDTO;
+import com.schoolmanagement.entity.SchoolClass;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.Subject;
+import com.schoolmanagement.entity.TeachingAssignment;
+import com.schoolmanagement.entity.TimetableSlot;
+import com.schoolmanagement.exception.ResourceNotFoundException;
+import com.schoolmanagement.exception.ScheduleConflictException;
+import com.schoolmanagement.repository.SchoolClassRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import com.schoolmanagement.repository.StaffRepository;
+import com.schoolmanagement.repository.TeachingAssignmentRepository;
+import com.schoolmanagement.repository.TimetableSlotRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class TimetableService {
+
+    private TimetableSlotRepository timetableSlotRepository;
+    private TeachingAssignmentRepository teachingAssignmentRepository;
+    private SchoolClassRepository schoolClassRepository;
+    private StaffRepository staffRepository;
+    private SemesterRepository semesterRepository;
+
+    public TimetableSlotDTO createSlot(TimetableSlot request) {
+        TeachingAssignment assignment = resolveTeachingAssignment(request.getTeachingAssignment());
+        assertNoConflict(assignment, request.getDayOfWeek(), request.getPeriod(), request.getRoom(), null);
+
+        TimetableSlot slot = TimetableSlot.builder()
+                .teachingAssignment(assignment)
+                .dayOfWeek(request.getDayOfWeek())
+                .period(request.getPeriod())
+                .room(request.getRoom())
+                .build();
+
+        return mapToDTO(timetableSlotRepository.save(slot));
+    }
+
+    public TimetableSlotDTO updateSlot(Long id, TimetableSlot request) {
+        TimetableSlot slot = timetableSlotRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Timetable slot not found with id: " + id));
+
+        TeachingAssignment assignment = resolveTeachingAssignment(request.getTeachingAssignment());
+        assertNoConflict(assignment, request.getDayOfWeek(), request.getPeriod(), request.getRoom(), id);
+
+        slot.setTeachingAssignment(assignment);
+        slot.setDayOfWeek(request.getDayOfWeek());
+        slot.setPeriod(request.getPeriod());
+        slot.setRoom(request.getRoom());
+
+        return mapToDTO(timetableSlotRepository.save(slot));
+    }
+
+    public void deleteSlot(Long id) {
+        TimetableSlot slot = timetableSlotRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Timetable slot not found with id: " + id));
+        timetableSlotRepository.delete(slot);
+    }
+
+    public List<TimetableSlotDTO> getClassTimetable(Long classId, Long semesterId) {
+        SchoolClass schoolClass = schoolClassRepository.findById(classId)
+                .orElseThrow(() -> new ResourceNotFoundException("Class not found with id: " + classId));
+
+        List<TimetableSlot> slots = semesterId == null
+                ? timetableSlotRepository.findByTeachingAssignment_SchoolClass(schoolClass)
+                : timetableSlotRepository.findByTeachingAssignment_SchoolClassAndTeachingAssignment_Semester(
+                        schoolClass, resolveSemesterOrThrow(semesterId));
+
+        return slots.stream().map(this::mapToDTO).collect(Collectors.toList());
+    }
+
+    public List<TimetableSlotDTO> getTeacherTimetable(Long teacherId, Long semesterId) {
+        Staff teacher = staffRepository.findById(teacherId)
+                .orElseThrow(() -> new ResourceNotFoundException("Staff not found with id: " + teacherId));
+
+        List<TimetableSlot> slots = semesterId == null
+                ? timetableSlotRepository.findByTeachingAssignment_Teacher(teacher)
+                : timetableSlotRepository.findByTeachingAssignment_TeacherAndTeachingAssignment_Semester(
+                        teacher, resolveSemesterOrThrow(semesterId));
+
+        return slots.stream().map(this::mapToDTO).collect(Collectors.toList());
+    }
+
+    private Semester resolveSemesterOrThrow(Long semesterId) {
+        return semesterRepository.findById(semesterId)
+                .orElseThrow(() -> new ResourceNotFoundException("Semester not found with id: " + semesterId));
+    }
+
+    private void assertNoConflict(TeachingAssignment assignment, Integer dayOfWeek, Integer period, String room, Long excludeSlotId) {
+        Long semesterId = assignment.getSemester().getId();
+
+        if (timetableSlotRepository.existsTeacherConflict(assignment.getTeacher().getId(), semesterId, dayOfWeek, period, excludeSlotId)) {
+            throw new ScheduleConflictException("This teacher already has another class at that day/period this semester");
+        }
+        if (timetableSlotRepository.existsRoomConflict(room, semesterId, dayOfWeek, period, excludeSlotId)) {
+            throw new ScheduleConflictException("This room is already booked at that day/period this semester");
+        }
+        if (timetableSlotRepository.existsClassConflict(assignment.getSchoolClass().getId(), semesterId, dayOfWeek, period, excludeSlotId)) {
+            throw new ScheduleConflictException("This class already has another lesson at that day/period this semester");
+        }
+    }
+
+    private TeachingAssignment resolveTeachingAssignment(TeachingAssignment reference) {
+        if (reference == null || reference.getId() == null) {
+            throw new ResourceNotFoundException("A teachingAssignment id is required");
+        }
+        return teachingAssignmentRepository.findById(reference.getId())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Teaching assignment not found with id: " + reference.getId()));
+    }
+
+    private TimetableSlotDTO mapToDTO(TimetableSlot slot) {
+        TeachingAssignment assignment = slot.getTeachingAssignment();
+        SchoolClass schoolClass = assignment.getSchoolClass();
+        Subject subject = assignment.getSubject();
+        Staff teacher = assignment.getTeacher();
+
+        return TimetableSlotDTO.builder()
+                .id(slot.getId())
+                .teachingAssignmentId(assignment.getId())
+                .schoolClassId(schoolClass.getId())
+                .schoolClassLabel(schoolClass.getClassName() + "-" + schoolClass.getSection())
+                .subjectId(subject.getId())
+                .subjectName(subject.getName())
+                .teacherId(teacher.getId())
+                .teacherName(teacher.getUser() != null
+                        ? teacher.getUser().getFirstName() + " " + teacher.getUser().getLastName()
+                        : null)
+                .dayOfWeek(slot.getDayOfWeek())
+                .period(slot.getPeriod())
+                .room(slot.getRoom())
+                .createdAt(slot.getCreatedAt())
+                .updatedAt(slot.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/resources/db/migration/V4__teaching_timetable.sql
+++ b/backend/src/main/resources/db/migration/V4__teaching_timetable.sql
@@ -1,0 +1,46 @@
+-- =====================================================
+-- Phase 3.2: Teaching assignments (phân công giảng dạy) + Timetable
+-- (thời khoá biểu)
+-- =====================================================
+-- No backfill needed — nothing in the pre-3.2 schema represented
+-- teacher-subject-class assignments or weekly schedule slots.
+--
+-- Note: teacher/room/class double-booking (same semester + day_of_week +
+-- period) can't be expressed as a plain UNIQUE constraint here since the
+-- teacher/room/class all live behind teaching_assignment_id, not as direct
+-- columns on timetable_slots — enforced instead in TimetableService via
+-- TimetableSlotRepository.existsTeacherConflict/existsRoomConflict/
+-- existsClassConflict before every insert/update.
+-- =====================================================
+
+CREATE TABLE `teaching_assignments` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `school_class_id` bigint NOT NULL,
+  `subject_id` bigint NOT NULL,
+  `teacher_id` bigint NOT NULL,
+  `semester_id` bigint NOT NULL,
+  `created_at` datetime(6) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_teaching_assignment_class_subject_semester` (`school_class_id`, `subject_id`, `semester_id`),
+  KEY `fk_ta_subject` (`subject_id`),
+  KEY `fk_ta_teacher` (`teacher_id`),
+  KEY `fk_ta_semester` (`semester_id`),
+  CONSTRAINT `fk_ta_school_class` FOREIGN KEY (`school_class_id`) REFERENCES `classes` (`id`),
+  CONSTRAINT `fk_ta_subject` FOREIGN KEY (`subject_id`) REFERENCES `subjects` (`id`),
+  CONSTRAINT `fk_ta_teacher` FOREIGN KEY (`teacher_id`) REFERENCES `staff` (`id`),
+  CONSTRAINT `fk_ta_semester` FOREIGN KEY (`semester_id`) REFERENCES `semesters` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `timetable_slots` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `teaching_assignment_id` bigint NOT NULL,
+  `day_of_week` int NOT NULL,
+  `period` int NOT NULL,
+  `room` varchar(255) NOT NULL,
+  `created_at` datetime(6) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk_ts_teaching_assignment` (`teaching_assignment_id`),
+  CONSTRAINT `fk_ts_teaching_assignment` FOREIGN KEY (`teaching_assignment_id`) REFERENCES `teaching_assignments` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/src/test/java/com/schoolmanagement/controller/TeachingTimetableIntegrationTest.java
+++ b/backend/src/test/java/com/schoolmanagement/controller/TeachingTimetableIntegrationTest.java
@@ -1,0 +1,325 @@
+package com.schoolmanagement.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.AcademicYearStatus;
+import com.schoolmanagement.entity.EmploymentStatus;
+import com.schoolmanagement.entity.Role;
+import com.schoolmanagement.entity.SchoolClass;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.SemesterName;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.StaffPosition;
+import com.schoolmanagement.entity.Subject;
+import com.schoolmanagement.entity.SubjectCategory;
+import com.schoolmanagement.entity.TeachingAssignment;
+import com.schoolmanagement.entity.TimetableSlot;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.repository.AcademicYearRepository;
+import com.schoolmanagement.repository.SchoolClassRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import com.schoolmanagement.repository.StaffRepository;
+import com.schoolmanagement.repository.SubjectRepository;
+import com.schoolmanagement.repository.TeachingAssignmentRepository;
+import com.schoolmanagement.repository.TimetableSlotRepository;
+import com.schoolmanagement.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration test for /v1/teaching-assignments and /v1/timetable — real
+ * Spring context + local MySQL via the "test" profile. Each test rolls back
+ * (@Transactional), so it never depends on — or pollutes — seeded data.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class TeachingTimetableIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private AcademicYearRepository academicYearRepository;
+    @Autowired
+    private SemesterRepository semesterRepository;
+    @Autowired
+    private SchoolClassRepository schoolClassRepository;
+    @Autowired
+    private SubjectRepository subjectRepository;
+    @Autowired
+    private StaffRepository staffRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private TeachingAssignmentRepository teachingAssignmentRepository;
+    @Autowired
+    private TimetableSlotRepository timetableSlotRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Semester semester;
+    private SchoolClass classA;
+    private SchoolClass classB;
+    private Subject subject;
+    private Staff teacher1;
+    private Staff teacher2;
+
+    @BeforeEach
+    void setUp() {
+        AcademicYear year = academicYearRepository.save(AcademicYear.builder()
+                .name("ITEST-TT-2099-2100")
+                .startDate(LocalDate.of(2099, 9, 1))
+                .endDate(LocalDate.of(2100, 5, 31))
+                .status(AcademicYearStatus.ACTIVE)
+                .build());
+
+        semester = semesterRepository.save(Semester.builder()
+                .academicYear(year)
+                .name(SemesterName.HK1)
+                .startDate(year.getStartDate())
+                .endDate(year.getEndDate())
+                .build());
+
+        classA = schoolClassRepository.save(SchoolClass.builder()
+                .className("ITEST-TT-10").section("A").academicYear("2099-2100").build());
+        classB = schoolClassRepository.save(SchoolClass.builder()
+                .className("ITEST-TT-10").section("B").academicYear("2099-2100").build());
+
+        subject = subjectRepository.save(Subject.builder()
+                .code("ITEST-TT-SUBJ").name("ITEST Subject").category(SubjectCategory.BAT_BUOC).build());
+
+        teacher1 = staffRepository.save(Staff.builder()
+                .employeeId("ITEST-TT-EMP-1")
+                .user(newUser("itest.tt.teacher1"))
+                .position(StaffPosition.TEACHER)
+                .status(EmploymentStatus.ACTIVE)
+                .build());
+        teacher2 = staffRepository.save(Staff.builder()
+                .employeeId("ITEST-TT-EMP-2")
+                .user(newUser("itest.tt.teacher2"))
+                .position(StaffPosition.TEACHER)
+                .status(EmploymentStatus.ACTIVE)
+                .build());
+    }
+
+    private User newUser(String username) {
+        return userRepository.save(User.builder()
+                .username(username)
+                .email(username + "@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration")
+                .lastName("Teacher")
+                .role(Role.TEACHER)
+                .enabled(true)
+                .build());
+    }
+
+    private TeachingAssignment newAssignment(SchoolClass schoolClass, Staff teacher) {
+        return TeachingAssignment.builder()
+                .schoolClass(SchoolClass.builder().id(schoolClass.getId()).build())
+                .subject(Subject.builder().id(subject.getId()).build())
+                .teacher(Staff.builder().id(teacher.getId()).build())
+                .semester(Semester.builder().id(semester.getId()).build())
+                .build();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createTeachingAssignment_persistsAndReturnsIt() throws Exception {
+        mockMvc.perform(post("/v1/teaching-assignments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newAssignment(classA, teacher1))))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.schoolClassLabel").value("ITEST-TT-10-A"))
+                .andExpect(jsonPath("$.subjectCode").value("ITEST-TT-SUBJ"))
+                .andExpect(jsonPath("$.teacherName").value("Integration Teacher"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createTeachingAssignment_duplicateClassSubjectSemester_returns409() throws Exception {
+        teachingAssignmentRepository.save(resolvedAssignment(classA, teacher1));
+
+        mockMvc.perform(post("/v1/teaching-assignments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newAssignment(classA, teacher2))))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(roles = "TEACHER")
+    void createTeachingAssignment_asTeacher_returns403() throws Exception {
+        mockMvc.perform(post("/v1/teaching-assignments")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newAssignment(classA, teacher1))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteTeachingAssignment_withSlots_returns409() throws Exception {
+        TeachingAssignment saved = teachingAssignmentRepository.save(resolvedAssignment(classA, teacher1));
+        timetableSlotRepository.save(TimetableSlot.builder()
+                .teachingAssignment(saved).dayOfWeek(2).period(1).room("ITEST-ROOM").build());
+
+        mockMvc.perform(delete("/v1/teaching-assignments/{id}", saved.getId()))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSlot_persistsAndReturnsIt() throws Exception {
+        TeachingAssignment assignment = teachingAssignmentRepository.save(resolvedAssignment(classA, teacher1));
+
+        TimetableSlot slot = TimetableSlot.builder()
+                .teachingAssignment(TeachingAssignment.builder().id(assignment.getId()).build())
+                .dayOfWeek(2).period(1).room("ITEST-P101")
+                .build();
+
+        mockMvc.perform(post("/v1/timetable/slots")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(slot)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.dayOfWeek").value(2))
+                .andExpect(jsonPath("$.period").value(1))
+                .andExpect(jsonPath("$.room").value("ITEST-P101"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSlot_teacherDoubleBooked_returns409() throws Exception {
+        TeachingAssignment assignment1 = teachingAssignmentRepository.save(resolvedAssignment(classA, teacher1));
+        TeachingAssignment assignment2 = teachingAssignmentRepository.save(resolvedAssignment(classB, teacher1));
+        timetableSlotRepository.save(TimetableSlot.builder()
+                .teachingAssignment(assignment1).dayOfWeek(2).period(1).room("ITEST-P101").build());
+
+        TimetableSlot conflicting = TimetableSlot.builder()
+                .teachingAssignment(TeachingAssignment.builder().id(assignment2.getId()).build())
+                .dayOfWeek(2).period(1).room("ITEST-P102")
+                .build();
+
+        mockMvc.perform(post("/v1/timetable/slots")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(conflicting)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("teacher")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSlot_roomDoubleBooked_returns409() throws Exception {
+        TeachingAssignment assignment1 = teachingAssignmentRepository.save(resolvedAssignment(classA, teacher1));
+        TeachingAssignment assignment2 = teachingAssignmentRepository.save(resolvedAssignment(classB, teacher2));
+        timetableSlotRepository.save(TimetableSlot.builder()
+                .teachingAssignment(assignment1).dayOfWeek(2).period(1).room("ITEST-SHARED-ROOM").build());
+
+        TimetableSlot conflicting = TimetableSlot.builder()
+                .teachingAssignment(TeachingAssignment.builder().id(assignment2.getId()).build())
+                .dayOfWeek(2).period(1).room("ITEST-SHARED-ROOM")
+                .build();
+
+        mockMvc.perform(post("/v1/timetable/slots")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(conflicting)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("room")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSlot_noConflictDifferentRoom_returns201() throws Exception {
+        TeachingAssignment assignment1 = teachingAssignmentRepository.save(resolvedAssignment(classA, teacher1));
+        TeachingAssignment assignment2 = teachingAssignmentRepository.save(resolvedAssignment(classB, teacher2));
+        timetableSlotRepository.save(TimetableSlot.builder()
+                .teachingAssignment(assignment1).dayOfWeek(2).period(1).room("ITEST-P101").build());
+
+        TimetableSlot noConflict = TimetableSlot.builder()
+                .teachingAssignment(TeachingAssignment.builder().id(assignment2.getId()).build())
+                .dayOfWeek(2).period(1).room("ITEST-P999")
+                .build();
+
+        mockMvc.perform(post("/v1/timetable/slots")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(noConflict)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createSlot_invalidDayOfWeek_returns400() throws Exception {
+        TeachingAssignment assignment = teachingAssignmentRepository.save(resolvedAssignment(classA, teacher1));
+
+        TimetableSlot invalid = TimetableSlot.builder()
+                .teachingAssignment(TeachingAssignment.builder().id(assignment.getId()).build())
+                .dayOfWeek(8).period(1).room("ITEST-P101")
+                .build();
+
+        mockMvc.perform(post("/v1/timetable/slots")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalid)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getClassTimetable_returnsScheduledSlots() throws Exception {
+        TeachingAssignment assignment = teachingAssignmentRepository.save(resolvedAssignment(classA, teacher1));
+        timetableSlotRepository.save(TimetableSlot.builder()
+                .teachingAssignment(assignment).dayOfWeek(3).period(2).room("ITEST-P101").build());
+
+        mockMvc.perform(get("/v1/timetable/class/{classId}", classA.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].schoolClassLabel").value("ITEST-TT-10-A"))
+                .andExpect(jsonPath("$[0].dayOfWeek").value(3));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void getTeacherTimetable_returnsScheduledSlots() throws Exception {
+        TeachingAssignment assignment = teachingAssignmentRepository.save(resolvedAssignment(classA, teacher1));
+        timetableSlotRepository.save(TimetableSlot.builder()
+                .teachingAssignment(assignment).dayOfWeek(4).period(3).room("ITEST-P101").build());
+
+        mockMvc.perform(get("/v1/timetable/teacher/{teacherId}", teacher1.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].teacherName").value("Integration Teacher"))
+                .andExpect(jsonPath("$[0].dayOfWeek").value(4));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void deleteSlot_succeeds() throws Exception {
+        TeachingAssignment assignment = teachingAssignmentRepository.save(resolvedAssignment(classA, teacher1));
+        TimetableSlot slot = timetableSlotRepository.save(TimetableSlot.builder()
+                .teachingAssignment(assignment).dayOfWeek(5).period(4).room("ITEST-P101").build());
+
+        mockMvc.perform(delete("/v1/timetable/slots/{id}", slot.getId()))
+                .andExpect(status().isNoContent());
+    }
+
+    private TeachingAssignment resolvedAssignment(SchoolClass schoolClass, Staff teacher) {
+        return TeachingAssignment.builder()
+                .schoolClass(schoolClass)
+                .subject(subject)
+                .teacher(teacher)
+                .semester(semester)
+                .build();
+    }
+}


### PR DESCRIPTION
New entities + endpoints per IMPLEMENTATION_PLAN.md 3.2:

- entity/TeachingAssignment.java: FK to SchoolClass/Subject/Staff (teacher)/Semester, unique per (class, subject, semester) — one teacher per subject per class per term.
- entity/TimetableSlot.java: FK to TeachingAssignment, dayOfWeek (2-7, Thứ Hai=2..Thứ Bảy=7 — Vietnamese calendar convention, no Sunday), period (1-10), room.
- controller/TeachingAssignmentController.java: full CRUD at /v1/teaching-assignments, ADMIN/PRINCIPAL writes + TEACHER reads; delete refused (409) while slots still reference the assignment.
- controller/TimetableController.java: GET /v1/timetable/class/{id} and /teacher/{id} (optional semesterId filter), POST/PUT/DELETE /v1/timetable/slots.
- Schedule-conflict checking (the plan's explicit ask) lives in TimetableService + three JPQL queries on TimetableSlotRepository — can't be a DB unique constraint since teacher/room/class are all reached through teaching_assignment_id, not direct columns: a slot is refused (new ScheduleConflictException -> 409) if the same teacher, the same room, or the same class already has a slot at that day/period within the same semester. All three checked independently so the error message says which one collided.
- db/migration/V4__teaching_timetable.sql: the two new tables, no backfill (nothing pre-3.2 represented this data).

Add TeachingTimetableIntegrationTest (12 cases, real Spring context + local MySQL, @Transactional rollback): assignment create/duplicate/ RBAC, delete blocked while slots exist, slot create, teacher-conflict and room-conflict both rejected (409, distinguishable by message) while a same-day/period slot for an unrelated teacher+room is still accepted, invalid dayOfWeek rejected (400), class/teacher timetable reads, slot delete.

Verified live against local MySQL: created two teaching assignments for the same subject on different classes with the same teacher (allowed) — a slot for one, then a same-day/period slot for the other correctly rejected as a teacher conflict (409); a third assignment (different teacher/class) rejected for reusing the same room at that day/period (409), then accepted once given a different room (201); GET /v1/timetable/class/{id} and /teacher/{id} both return the scheduled slot; deleting a teaching assignment with a slot attached correctly refused (409). Full `mvn test` suite passes (41/41: 1 context + 11 academic-structure + 10 class + 12 teaching-timetable + 1 exception-handler + 6 auth).