### PR TITLE
Phase 3.4: Hanh kiem / Ren luyen (conduct records)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -44,6 +44,7 @@ http://localhost:8080/api/swagger-ui.html
 | Grades (legacy) | `/v1/grades/*` | Percentage-based assessments — kept for Phase 1-2 compatibility, not TT22-based |
 | Grade Records | `/v1/grade-records/*` | Điểm theo Thông tư 22/2021 — thang điểm 10, per component type (miệng/15p/1 tiết/giữa kỳ/cuối kỳ); supersedes Grades above. Điểm TB học kỳ/cả năm per subject via `/student/{id}/summary` and `/student/{id}/year-summary` |
 | Grade Config | `/v1/grade-config/*` | ADMIN-only: hệ số (weight) per component type, scoped by the academic year it starts applying from |
+| Conduct (Hạnh kiểm) | `/v1/conduct/*` | Đánh giá hạnh kiểm/rèn luyện theo học kỳ (TOT/KHA/TRUNG_BINH/YEU), one per student per semester. TEACHER may only write for students in the class they are GVCN of; class/semester roster view for bulk entry |
 | Fees | `/v1/fees/*` | Student fees & payments |
 | Library | `/v1/library/*` | Book catalog & borrowing |
 | Dashboard | `/v1/dashboard/stats` | Admin summary stats |
@@ -57,6 +58,7 @@ See [Swagger UI](http://localhost:8080/api/swagger-ui.html) for the full, curren
 - `V3__academic_structure.sql` added `AcademicYear`/`Semester`/`Subject` and backfilled them from the old free-text data (`classes.academic_year`, `grades.subject`). The old columns this replaces (`SchoolClass.academicYear` String, `Student.className`/`section`) are kept and marked `@Deprecated` on the entity — not dropped — so nothing already built against them breaks; new code should read/write `SchoolClass.academicYearRef` and `Student.currentClass` instead.
 - `V4__teaching_timetable.sql` added `TeachingAssignment`/`TimetableSlot` (no backfill — nothing pre-3.2 represented this data).
 - `V5__grading_tt22.sql` added `grade_records`/`grade_component_configs` (Thông tư 22/2021 grading). No backfill from the old `grades` table — the two scoring models (percentage-of-total vs. thang điểm 10 by component type) don't map onto each other automatically — and no default weight rows are seeded; an ADMIN must configure them via `POST /v1/grade-config` before anyone can enter grades.
+- `V6__conduct_records.sql` added `conduct_records` (hạnh kiểm/rèn luyện), one row per (student, semester) enforced by a unique constraint. No backfill — nothing pre-3.4 represented this data.
 - Create the database once:
   ```sql
   CREATE DATABASE school_management CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -97,7 +99,9 @@ Nothing is hard-coded — everything sensitive comes from environment variables 
 - To create an account with any other role, an authenticated **ADMIN** calls `POST /v1/users` with an explicit `role`.
 
 ### Object-level authorization (own-record access)
-Endpoints scoped to `{studentId}` in the path/query (currently: `/v1/grade-records/student/*`, `/v1/grade-records/{id}`) additionally check, for a caller with the `STUDENT` role only, that the id being requested is their own — a student cannot read another student's grades by id even though `hasRole('STUDENT')` alone would pass. `ADMIN`/`TEACHER` callers are unrestricted. This check isn't yet applied to the older Grades/Fees/Attendance modules (Phase 1-2), which currently authorize `STUDENT` by role only.
+Endpoints scoped to `{studentId}` in the path/query (currently: `/v1/grade-records/student/*`, `/v1/grade-records/{id}`, `/v1/conduct/student/{id}`) additionally check, for a caller with the `STUDENT` role only, that the id being requested is their own — a student cannot read another student's grades/conduct by id even though `hasRole('STUDENT')` alone would pass. `ADMIN`/`TEACHER` callers are unrestricted. This check isn't yet applied to the older Grades/Fees/Attendance modules (Phase 1-2), which currently authorize `STUDENT` by role only.
+
+`/v1/conduct` additionally enforces a GVCN (homeroom-teacher) check on writes: a `TEACHER` may only create/update a conduct record for a student in a class they are `classTeacher` of, and may only submit it under their own staff profile (`evaluatedBy` must match). `ADMIN` is unrestricted. Updating an existing record re-checks this against *both* the record's current student and the (possibly different) target student, so a teacher can't "steal" another GVCN's record by reassigning it to their own class.
 
 ### Input validation & error responses
 - Every create/update endpoint validates its body (`@Valid` + Bean Validation) and returns `400` with a field-level message on failure.
@@ -187,6 +191,8 @@ backend/
 
 ## 🚀 Future enhancements
 
-See the "Giai đoạn 3" section of [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) for the full roadmap — hạnh kiểm, promotion workflow (xét lên lớp/ở lại/tốt nghiệp), parent portal & sổ liên lạc điện tử, admissions, PDF/Excel reports, audit log. (3.1 Năm học/Học kỳ/Môn học, 3.2 Phân công giảng dạy & Thời khoá biểu, and 3.3 Điểm theo TT22 — điểm TB formulas + entity/API framework — are done, above.)
+See the "Giai đoạn 3" section of [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) for the full roadmap — promotion workflow (xét lên lớp/ở lại/tốt nghiệp), parent portal & sổ liên lạc điện tử, admissions, PDF/Excel reports, audit log. (3.1 Năm học/Học kỳ/Môn học, 3.2 Phân công giảng dạy & Thời khoá biểu, 3.3 Điểm theo TT22 — điểm TB formulas + entity/API framework, and 3.4 Hạnh kiểm/Rèn luyện are done, above.)
 
 **Note on 3.3**: `GradeClassification` (xếp loại học lực: Tốt/Giỏi/Khá/Đạt/Trung bình/Yếu/Chưa đạt/Kém) exists as vocabulary and the DTOs carry a `classification` field, but the actual TT22/58 threshold logic is **not implemented** — it's deliberately deferred pending confirmation from someone with education-domain expertise on the exact score cutoffs and the môn Toán/Ngữ văn condition. The field is always `null` (omitted from JSON) until that's implemented.
+
+**Note on 3.4**: the class/semester roster (`GET /v1/conduct/class/{classId}/semester/{semesterId}`) matches students to a class via the same (deprecated) `className`/`section` string pair `SchoolClassService.getStudentsInClass` already uses codebase-wide — not scoped by academic year, so a reused className/section across years could over-match. Pre-existing limitation of that roster convention (Phase 1-2), not new to this endpoint; a real fix means wiring up `Student.currentClass` (the FK meant to replace it) everywhere roster membership is checked, which no code path currently maintains on write.

--- a/backend/src/main/java/com/schoolmanagement/controller/ConductController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/ConductController.java
@@ -1,0 +1,66 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.dto.ConductRecordDTO;
+import com.schoolmanagement.dto.ConductRosterEntryDTO;
+import com.schoolmanagement.entity.ConductRecord;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.service.ConductRecordService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/conduct")
+@AllArgsConstructor
+@Tag(name = "Conduct (Hạnh kiểm)", description = "Đánh giá hạnh kiểm/rèn luyện theo học kỳ. TEACHER chỉ được ghi cho lớp mình làm GVCN (classTeacher).")
+public class ConductController {
+
+    private ConductRecordService conductRecordService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('TEACHER')")
+    @Operation(summary = "Create a conduct record",
+            description = "A TEACHER may only record conduct for students in the class they are GVCN of (403 otherwise).")
+    public ResponseEntity<ConductRecordDTO> createConductRecord(
+            @Valid @RequestBody ConductRecord request, Authentication authentication) {
+        User requester = (User) authentication.getPrincipal();
+        return new ResponseEntity<>(conductRecordService.createConductRecord(request, requester), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('TEACHER')")
+    @Operation(summary = "Update a conduct record",
+            description = "A TEACHER may only update conduct for students in the class they are GVCN of (403 otherwise).")
+    public ResponseEntity<ConductRecordDTO> updateConductRecord(
+            @PathVariable Long id, @Valid @RequestBody ConductRecord request, Authentication authentication) {
+        User requester = (User) authentication.getPrincipal();
+        return new ResponseEntity<>(conductRecordService.updateConductRecord(id, request, requester), HttpStatus.OK);
+    }
+
+    @GetMapping("/student/{studentId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'TEACHER', 'STUDENT')")
+    @Operation(summary = "Get every conduct record for a student (all semesters)",
+            description = "A STUDENT caller may only fetch their own conduct records (403 otherwise).")
+    public ResponseEntity<List<ConductRecordDTO>> getStudentConductRecords(
+            @PathVariable Long studentId, Authentication authentication) {
+        User requester = (User) authentication.getPrincipal();
+        return new ResponseEntity<>(conductRecordService.getStudentConductRecords(studentId, requester), HttpStatus.OK);
+    }
+
+    @GetMapping("/class/{classId}/semester/{semesterId}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('TEACHER')")
+    @Operation(summary = "Bảng đánh giá hạnh kiểm hàng loạt cho GVCN",
+            description = "One row per student currently in the class; rating/remarks are null for students not yet evaluated this semester.")
+    public ResponseEntity<List<ConductRosterEntryDTO>> getClassSemesterRoster(
+            @PathVariable Long classId, @PathVariable Long semesterId) {
+        return new ResponseEntity<>(conductRecordService.getClassSemesterRoster(classId, semesterId), HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/ConductRecordDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/ConductRecordDTO.java
@@ -1,0 +1,32 @@
+package com.schoolmanagement.dto;
+
+import com.schoolmanagement.entity.ConductRating;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Schema(description = "Đánh giá hạnh kiểm/rèn luyện của một học sinh trong một học kỳ.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConductRecordDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private Long studentId;
+    private String studentName;
+    private Long semesterId;
+    private String semesterLabel;
+    private ConductRating rating;
+    private String remarks;
+    private Long evaluatedById;
+    private String evaluatedByName;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/ConductRosterEntryDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/ConductRosterEntryDTO.java
@@ -1,0 +1,33 @@
+package com.schoolmanagement.dto;
+
+import com.schoolmanagement.entity.ConductRating;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Schema(description = "One row of the GVCN's bulk conduct-evaluation table for a class/semester — one row per student in the class, whether or not they've been evaluated yet.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConductRosterEntryDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long studentId;
+    private String studentName;
+    private String rollNumber;
+
+    @Schema(description = "null if this student has no conduct record yet for this semester")
+    private Long conductRecordId;
+
+    @Schema(description = "null if this student has no conduct record yet for this semester")
+    private ConductRating rating;
+
+    private String remarks;
+    private Long evaluatedById;
+    private String evaluatedByName;
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/ConductRating.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/ConductRating.java
@@ -1,0 +1,12 @@
+package com.schoolmanagement.entity;
+
+/**
+ * Xếp loại hạnh kiểm/rèn luyện — per semester, always alongside (never
+ * instead of) học lực in a Vietnamese học bạ. Per IMPLEMENTATION_PLAN.md 3.4.
+ */
+public enum ConductRating {
+    TOT,
+    KHA,
+    TRUNG_BINH,
+    YEU
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/ConductRecord.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/ConductRecord.java
@@ -1,0 +1,66 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Đánh giá hạnh kiểm/rèn luyện của một học sinh trong một học kỳ — per
+ * IMPLEMENTATION_PLAN.md 3.4. One record per (student, semester): a
+ * student's conduct is re-evaluated (not accumulated) each semester.
+ */
+@Entity
+@Table(name = "conduct_records", uniqueConstraints = @UniqueConstraint(
+        name = "uk_conduct_student_semester", columnNames = {"student_id", "semester_id"}))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ConductRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "semester_id", nullable = false)
+    private Semester semester;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ConductRating rating;
+
+    @Column(columnDefinition = "TEXT")
+    private String remarks;
+
+    /** The GVCN (or ADMIN) who made this evaluation. */
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "evaluated_by_id", nullable = false)
+    private Staff evaluatedBy;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/ConductRecordRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/ConductRecordRepository.java
@@ -1,0 +1,18 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.ConductRecord;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ConductRecordRepository extends JpaRepository<ConductRecord, Long> {
+    Optional<ConductRecord> findByStudentAndSemester(Student student, Semester semester);
+    List<ConductRecord> findByStudent(Student student);
+    List<ConductRecord> findBySemesterAndStudentIn(Semester semester, List<Student> students);
+    boolean existsByStudentAndSemester(Student student, Semester semester);
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/StaffRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/StaffRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 @Repository
 public interface StaffRepository extends JpaRepository<Staff, Long> {
     Optional<Staff> findByEmployeeId(String employeeId);
+    Optional<Staff> findByUserId(Long userId);
     List<Staff> findByStatus(EmploymentStatus status);
     long countByStatus(EmploymentStatus status);
     List<Staff> findByPosition(StaffPosition position);

--- a/backend/src/main/java/com/schoolmanagement/service/ConductRecordService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/ConductRecordService.java
@@ -1,0 +1,257 @@
+package com.schoolmanagement.service;
+
+import com.schoolmanagement.dto.ConductRecordDTO;
+import com.schoolmanagement.dto.ConductRosterEntryDTO;
+import com.schoolmanagement.entity.ConductRecord;
+import com.schoolmanagement.entity.Role;
+import com.schoolmanagement.entity.SchoolClass;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.Student;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.exception.DuplicateResourceException;
+import com.schoolmanagement.exception.ResourceNotFoundException;
+import com.schoolmanagement.repository.ConductRecordRepository;
+import com.schoolmanagement.repository.SchoolClassRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import com.schoolmanagement.repository.StaffRepository;
+import com.schoolmanagement.repository.StudentRepository;
+import com.schoolmanagement.util.EntityResolver;
+import lombok.AllArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Hạnh kiểm/rèn luyện per IMPLEMENTATION_PLAN.md 3.4 — one ConductRecord per
+ * (student, semester). A TEACHER may only create/update conduct records for
+ * students in the class they are GVCN (homeroom teacher) of; ADMIN is
+ * unrestricted. Reads are open to ADMIN/TEACHER; a STUDENT caller may only
+ * read their own records (same object-level pattern as GradeRecordService).
+ */
+@Service
+@AllArgsConstructor
+@Transactional
+public class ConductRecordService {
+
+    private ConductRecordRepository conductRecordRepository;
+    private StudentRepository studentRepository;
+    private SemesterRepository semesterRepository;
+    private StaffRepository staffRepository;
+    private SchoolClassRepository schoolClassRepository;
+
+    public ConductRecordDTO createConductRecord(ConductRecord request, User requester) {
+        Student student = resolveStudent(request.getStudent());
+        Semester semester = resolveSemester(request.getSemester());
+        Staff evaluatedBy = resolveStaff(request.getEvaluatedBy());
+
+        enforceHomeroomWriteAccess(student, evaluatedBy, requester);
+
+        if (conductRecordRepository.existsByStudentAndSemester(student, semester)) {
+            throw new DuplicateResourceException(
+                    "A conduct record already exists for this student in this semester — use PUT to update it");
+        }
+
+        ConductRecord record = ConductRecord.builder()
+                .student(student)
+                .semester(semester)
+                .rating(request.getRating())
+                .remarks(request.getRemarks())
+                .evaluatedBy(evaluatedBy)
+                .build();
+
+        try {
+            return mapToDTO(conductRecordRepository.save(record));
+        } catch (DataIntegrityViolationException ex) {
+            // Two concurrent requests can both pass the exists() check above before
+            // either commits; surface that race as 409, not a masked 500.
+            throw new DuplicateResourceException(
+                    "A conduct record already exists for this student in this semester — use PUT to update it");
+        }
+    }
+
+    public ConductRecordDTO updateConductRecord(Long id, ConductRecord request, User requester) {
+        ConductRecord record = conductRecordRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Conduct record not found with id: " + id));
+
+        // Authorize against the record as it stands today FIRST - a TEACHER must
+        // already be the GVCN of whichever class this record currently belongs
+        // to before touching it at all, otherwise they could "reassign" someone
+        // else's conduct record to their own student and pass the check below.
+        enforceHomeroomWriteAccess(record.getStudent(), record.getEvaluatedBy(), requester);
+
+        Student student = resolveStudent(request.getStudent());
+        Semester semester = resolveSemester(request.getSemester());
+        Staff evaluatedBy = resolveStaff(request.getEvaluatedBy());
+
+        // And also authorize against the (possibly different) target student/evaluator.
+        enforceHomeroomWriteAccess(student, evaluatedBy, requester);
+
+        boolean changingKey = !student.getId().equals(record.getStudent().getId())
+                || !semester.getId().equals(record.getSemester().getId());
+        if (changingKey && conductRecordRepository.existsByStudentAndSemester(student, semester)) {
+            throw new DuplicateResourceException(
+                    "A conduct record already exists for this student in this semester");
+        }
+
+        record.setStudent(student);
+        record.setSemester(semester);
+        record.setRating(request.getRating());
+        record.setRemarks(request.getRemarks());
+        record.setEvaluatedBy(evaluatedBy);
+
+        try {
+            return mapToDTO(conductRecordRepository.save(record));
+        } catch (DataIntegrityViolationException ex) {
+            throw new DuplicateResourceException(
+                    "A conduct record already exists for this student in this semester");
+        }
+    }
+
+    public List<ConductRecordDTO> getStudentConductRecords(Long studentId, User requester) {
+        enforceOwnStudentAccess(studentId, requester);
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Student not found with id: " + studentId));
+
+        return conductRecordRepository.findByStudent(student)
+                .stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Bảng đánh giá hàng loạt cho GVCN — one row per student currently in the
+     * class. Roster membership is matched on the same (deprecated)
+     * className/section pair {@link com.schoolmanagement.service.SchoolClassService#getStudentsInClass}
+     * already uses codebase-wide — not scoped by academic year, so a
+     * className/section reused across years would over-match. Pre-existing
+     * limitation of that roster convention, not new to this endpoint.
+     */
+    public List<ConductRosterEntryDTO> getClassSemesterRoster(Long classId, Long semesterId) {
+        SchoolClass schoolClass = schoolClassRepository.findById(classId)
+                .orElseThrow(() -> new ResourceNotFoundException("Class not found with id: " + classId));
+        Semester semester = semesterRepository.findById(semesterId)
+                .orElseThrow(() -> new ResourceNotFoundException("Semester not found with id: " + semesterId));
+
+        List<Student> roster = studentRepository.findByClassNameAndSection(
+                schoolClass.getClassName(), schoolClass.getSection());
+
+        Map<Long, ConductRecord> byStudentId = conductRecordRepository
+                .findBySemesterAndStudentIn(semester, roster)
+                .stream()
+                .collect(Collectors.toMap(r -> r.getStudent().getId(), Function.identity()));
+
+        return roster.stream()
+                .map(student -> {
+                    ConductRecord record = byStudentId.get(student.getId());
+                    ConductRosterEntryDTO.ConductRosterEntryDTOBuilder entry = ConductRosterEntryDTO.builder()
+                            .studentId(student.getId())
+                            .studentName(studentName(student))
+                            .rollNumber(student.getRollNumber());
+
+                    if (record != null) {
+                        entry.conductRecordId(record.getId())
+                                .rating(record.getRating())
+                                .remarks(record.getRemarks())
+                                .evaluatedById(record.getEvaluatedBy().getId())
+                                .evaluatedByName(staffName(record.getEvaluatedBy()));
+                    }
+
+                    return entry.build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Only a TEACHER is restricted, and only to a class they are GVCN of;
+     * ADMIN is unrestricted. Checked via "does any of this teacher's homeroom
+     * classes match the student's className/section" (schoolClassRepository.
+     * findByClassTeacher, a List) rather than "look up the student's one
+     * class and compare its teacher" (findByClassNameAndSection, an Optional)
+     * — className/section isn't unique across academic years, so the latter
+     * can throw IncorrectResultSizeDataAccessException if the same
+     * class name/section exists in more than one year.
+     */
+    private void enforceHomeroomWriteAccess(Student student, Staff evaluatedBy, User requester) {
+        if (requester == null || requester.getRole() != Role.TEACHER) {
+            return;
+        }
+
+        Staff teacherStaff = staffRepository.findByUserId(requester.getId())
+                .orElseThrow(() -> new AccessDeniedException("No staff profile linked to this account"));
+
+        if (student.getClassName() == null || student.getSection() == null) {
+            throw new ResourceNotFoundException("Student " + student.getId() + " has no class assigned");
+        }
+        boolean isHomeroomOfStudentsClass = schoolClassRepository.findByClassTeacher(teacherStaff).stream()
+                .anyMatch(cls -> student.getClassName().equals(cls.getClassName())
+                        && student.getSection().equals(cls.getSection()));
+        if (!isHomeroomOfStudentsClass) {
+            throw new AccessDeniedException(
+                    "Only the class's GVCN (homeroom teacher) may record conduct for this student");
+        }
+
+        if (evaluatedBy != null && !teacherStaff.getId().equals(evaluatedBy.getId())) {
+            throw new AccessDeniedException(
+                    "A TEACHER may only submit conduct evaluations under their own staff profile");
+        }
+    }
+
+    /** Only a STUDENT is restricted, and only to their own id; ADMIN/TEACHER are unrestricted. */
+    private void enforceOwnStudentAccess(Long targetStudentId, User requester) {
+        if (requester == null || requester.getRole() != Role.STUDENT) {
+            return;
+        }
+        Student own = studentRepository.findByUserId(requester.getId())
+                .orElseThrow(() -> new AccessDeniedException("No student profile linked to this account"));
+        if (!own.getId().equals(targetStudentId)) {
+            throw new AccessDeniedException("Students may only access their own conduct records");
+        }
+    }
+
+    private Student resolveStudent(Student reference) {
+        return EntityResolver.resolveOrThrow(studentRepository, reference != null ? reference.getId() : null, "Student");
+    }
+
+    private Semester resolveSemester(Semester reference) {
+        return EntityResolver.resolveOrThrow(semesterRepository, reference != null ? reference.getId() : null, "Semester");
+    }
+
+    private Staff resolveStaff(Staff reference) {
+        return EntityResolver.resolveOrThrow(staffRepository, reference != null ? reference.getId() : null, "Staff (evaluatedBy)");
+    }
+
+    private String studentName(Student student) {
+        return student.getUser() != null ? student.getUser().getFirstName() + " " + student.getUser().getLastName() : null;
+    }
+
+    private String staffName(Staff staff) {
+        return staff.getUser() != null ? staff.getUser().getFirstName() + " " + staff.getUser().getLastName() : null;
+    }
+
+    private ConductRecordDTO mapToDTO(ConductRecord record) {
+        Student student = record.getStudent();
+        Semester semester = record.getSemester();
+        Staff evaluatedBy = record.getEvaluatedBy();
+
+        return ConductRecordDTO.builder()
+                .id(record.getId())
+                .studentId(student.getId())
+                .studentName(studentName(student))
+                .semesterId(semester.getId())
+                .semesterLabel(semester.getAcademicYear().getName() + " - " + semester.getName())
+                .rating(record.getRating())
+                .remarks(record.getRemarks())
+                .evaluatedById(evaluatedBy.getId())
+                .evaluatedByName(staffName(evaluatedBy))
+                .createdAt(record.getCreatedAt())
+                .updatedAt(record.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/resources/db/migration/V6__conduct_records.sql
+++ b/backend/src/main/resources/db/migration/V6__conduct_records.sql
@@ -1,0 +1,25 @@
+-- =====================================================
+-- Phase 3.4: Hanh kiem / Ren luyen (conduct records)
+-- =====================================================
+-- One row per (student, semester) - a student's conduct is re-evaluated,
+-- not accumulated, each semester. No backfill: nothing pre-3.4 represented
+-- this data.
+-- =====================================================
+
+CREATE TABLE `conduct_records` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `student_id` bigint NOT NULL,
+  `semester_id` bigint NOT NULL,
+  `rating` enum('TOT','KHA','TRUNG_BINH','YEU') NOT NULL,
+  `remarks` text,
+  `evaluated_by_id` bigint NOT NULL,
+  `created_at` datetime(6) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_conduct_student_semester` (`student_id`, `semester_id`),
+  KEY `fk_conduct_semester` (`semester_id`),
+  KEY `fk_conduct_evaluated_by` (`evaluated_by_id`),
+  CONSTRAINT `fk_conduct_student` FOREIGN KEY (`student_id`) REFERENCES `students` (`id`),
+  CONSTRAINT `fk_conduct_semester` FOREIGN KEY (`semester_id`) REFERENCES `semesters` (`id`),
+  CONSTRAINT `fk_conduct_evaluated_by` FOREIGN KEY (`evaluated_by_id`) REFERENCES `staff` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/src/test/java/com/schoolmanagement/controller/ConductRecordIntegrationTest.java
+++ b/backend/src/test/java/com/schoolmanagement/controller/ConductRecordIntegrationTest.java
@@ -1,0 +1,352 @@
+package com.schoolmanagement.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.AcademicYearStatus;
+import com.schoolmanagement.entity.ConductRating;
+import com.schoolmanagement.entity.ConductRecord;
+import com.schoolmanagement.entity.EmploymentStatus;
+import com.schoolmanagement.entity.Role;
+import com.schoolmanagement.entity.SchoolClass;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.SemesterName;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.StaffPosition;
+import com.schoolmanagement.entity.Student;
+import com.schoolmanagement.entity.StudentStatus;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.repository.AcademicYearRepository;
+import com.schoolmanagement.repository.ConductRecordRepository;
+import com.schoolmanagement.repository.SchoolClassRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import com.schoolmanagement.repository.StaffRepository;
+import com.schoolmanagement.repository.StudentRepository;
+import com.schoolmanagement.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration test for /v1/conduct — real Spring context + local MySQL via
+ * the "test" profile. Each test rolls back (@Transactional). Covers the
+ * IMPLEMENTATION_PLAN.md 3.4 permission rule: a TEACHER may only write
+ * conduct for students in the class they are GVCN (homeroom teacher) of.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class ConductRecordIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private AcademicYearRepository academicYearRepository;
+    @Autowired
+    private SemesterRepository semesterRepository;
+    @Autowired
+    private SchoolClassRepository schoolClassRepository;
+    @Autowired
+    private StudentRepository studentRepository;
+    @Autowired
+    private StaffRepository staffRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ConductRecordRepository conductRecordRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Semester hk1;
+    private Staff homeroomTeacher;
+    private Staff otherTeacher;
+    private Student student;       // in homeroomTeacher's class
+    private Student otherStudent;  // in a different class
+    private User adminUser;
+    private User homeroomTeacherUser;
+    private User otherTeacherUser;
+    private User studentUser;
+    private User otherStudentUser;
+
+    @BeforeEach
+    void setUp() {
+        AcademicYear academicYear = academicYearRepository.save(AcademicYear.builder()
+                .name("2099-2100") // far-future year, never collides with real/seed data
+                .startDate(LocalDate.of(2099, 9, 1))
+                .endDate(LocalDate.of(2100, 5, 31))
+                .status(AcademicYearStatus.ACTIVE)
+                .build());
+        hk1 = semesterRepository.save(Semester.builder()
+                .academicYear(academicYear).name(SemesterName.HK1)
+                .startDate(academicYear.getStartDate()).endDate(LocalDate.of(2100, 1, 15))
+                .build());
+
+        adminUser = userRepository.save(User.builder()
+                .username("itest.cond.admin").email("itest.cond.admin@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Admin").role(Role.ADMIN).enabled(true).build());
+
+        homeroomTeacherUser = userRepository.save(User.builder()
+                .username("itest.cond.gvcn").email("itest.cond.gvcn@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Gvcn").role(Role.TEACHER).enabled(true).build());
+        homeroomTeacher = staffRepository.save(Staff.builder()
+                .employeeId("ITEST-COND-GVCN").user(homeroomTeacherUser)
+                .position(StaffPosition.TEACHER).status(EmploymentStatus.ACTIVE).build());
+
+        otherTeacherUser = userRepository.save(User.builder()
+                .username("itest.cond.other-teacher").email("itest.cond.other-teacher@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("OtherTeacher").role(Role.TEACHER).enabled(true).build());
+        otherTeacher = staffRepository.save(Staff.builder()
+                .employeeId("ITEST-COND-OTHER").user(otherTeacherUser)
+                .position(StaffPosition.TEACHER).status(EmploymentStatus.ACTIVE).build());
+
+        SchoolClass homeroomClass = schoolClassRepository.save(SchoolClass.builder()
+                .className("ITEST-COND-10").section("A").academicYear("2099-2100")
+                .classTeacher(homeroomTeacher).build());
+        schoolClassRepository.save(SchoolClass.builder()
+                .className("ITEST-COND-10").section("B").academicYear("2099-2100")
+                .classTeacher(otherTeacher).build());
+
+        studentUser = userRepository.save(User.builder()
+                .username("itest.cond.student").email("itest.cond.student@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Student").role(Role.STUDENT).enabled(true).build());
+        student = studentRepository.save(Student.builder()
+                .rollNumber("ITEST-COND-ROLL-1").admissionNumber("ITEST-COND-ADM-1")
+                .user(studentUser).status(StudentStatus.ACTIVE)
+                .className(homeroomClass.getClassName()).section(homeroomClass.getSection())
+                .build());
+
+        otherStudentUser = userRepository.save(User.builder()
+                .username("itest.cond.student2").email("itest.cond.student2@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("StudentTwo").role(Role.STUDENT).enabled(true).build());
+        otherStudent = studentRepository.save(Student.builder()
+                .rollNumber("ITEST-COND-ROLL-2").admissionNumber("ITEST-COND-ADM-2")
+                .user(otherStudentUser).status(StudentStatus.ACTIVE)
+                .className("ITEST-COND-10").section("B")
+                .build());
+    }
+
+    /**
+     * @WithMockUser's principal is Spring Security's own User, not our
+     * com.schoolmanagement.entity.User — every write/self-scoped read endpoint
+     * under test casts authentication.getPrincipal() to our User, so those
+     * tests authenticate as a real domain User instead.
+     */
+    private RequestPostProcessor asUser(User user, String role) {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                user, null, List.of(new SimpleGrantedAuthority("ROLE_" + role))));
+    }
+
+    private String conductPayload(Student forStudent, Staff evaluator, ConductRating rating, String remarks) throws Exception {
+        ConductRecord request = ConductRecord.builder()
+                .student(Student.builder().id(forStudent.getId()).build())
+                .semester(Semester.builder().id(hk1.getId()).build())
+                .rating(rating)
+                .remarks(remarks)
+                .evaluatedBy(Staff.builder().id(evaluator.getId()).build())
+                .build();
+        return objectMapper.writeValueAsString(request);
+    }
+
+    @Test
+    void createConductRecord_asHomeroomTeacher_persistsAndReturnsIt() throws Exception {
+        mockMvc.perform(post("/v1/conduct")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(conductPayload(student, homeroomTeacher, ConductRating.TOT, "Ngoan"))
+                        .with(asUser(homeroomTeacherUser, "TEACHER")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.rating").value("TOT"))
+                .andExpect(jsonPath("$.studentName").value("Integration Student"));
+    }
+
+    @Test
+    void createConductRecord_asNonHomeroomTeacher_returns403() throws Exception {
+        mockMvc.perform(post("/v1/conduct")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(conductPayload(student, otherTeacher, ConductRating.TOT, "Ngoan"))
+                        .with(asUser(otherTeacherUser, "TEACHER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void createConductRecord_asAdmin_forAnyClass_returns201() throws Exception {
+        mockMvc.perform(post("/v1/conduct")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(conductPayload(otherStudent, otherTeacher, ConductRating.KHA, "OK"))
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void createConductRecord_duplicateStudentSemester_returns409() throws Exception {
+        conductRecordRepository.save(ConductRecord.builder()
+                .student(student).semester(hk1).rating(ConductRating.TOT)
+                .evaluatedBy(homeroomTeacher).build());
+
+        mockMvc.perform(post("/v1/conduct")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(conductPayload(student, homeroomTeacher, ConductRating.KHA, "again"))
+                        .with(asUser(homeroomTeacherUser, "TEACHER")))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void createConductRecord_asStudent_returns403() throws Exception {
+        // @PreAuthorize denies before the controller body runs, so a generic
+        // @WithMockUser (no real User principal) is fine here.
+        mockMvc.perform(post("/v1/conduct")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(conductPayload(student, homeroomTeacher, ConductRating.TOT, "x")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void updateConductRecord_asHomeroomTeacher_updatesSuccessfully() throws Exception {
+        ConductRecord existing = conductRecordRepository.save(ConductRecord.builder()
+                .student(student).semester(hk1).rating(ConductRating.TOT)
+                .evaluatedBy(homeroomTeacher).build());
+
+        mockMvc.perform(put("/v1/conduct/{id}", existing.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(conductPayload(student, homeroomTeacher, ConductRating.KHA, "Revised"))
+                        .with(asUser(homeroomTeacherUser, "TEACHER")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rating").value("KHA"))
+                .andExpect(jsonPath("$.remarks").value("Revised"));
+    }
+
+    @Test
+    void updateConductRecord_asNonHomeroomTeacher_returns403() throws Exception {
+        ConductRecord existing = conductRecordRepository.save(ConductRecord.builder()
+                .student(student).semester(hk1).rating(ConductRating.TOT)
+                .evaluatedBy(homeroomTeacher).build());
+
+        mockMvc.perform(put("/v1/conduct/{id}", existing.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(conductPayload(student, otherTeacher, ConductRating.YEU, "unauthorized change"))
+                        .with(asUser(otherTeacherUser, "TEACHER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void updateConductRecord_hijackAnotherGvcnsRecord_returns403AndLeavesItUnchanged() throws Exception {
+        // Record belongs to otherStudent (GVCN: otherTeacher). homeroomTeacher
+        // (GVCN of a different class) must not be able to "steal" this record
+        // by reassigning it to their own student.
+        ConductRecord existing = conductRecordRepository.save(ConductRecord.builder()
+                .student(otherStudent).semester(hk1).rating(ConductRating.TOT)
+                .evaluatedBy(otherTeacher).build());
+
+        mockMvc.perform(put("/v1/conduct/{id}", existing.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(conductPayload(student, homeroomTeacher, ConductRating.YEU, "hijacked"))
+                        .with(asUser(homeroomTeacherUser, "TEACHER")))
+                .andExpect(status().isForbidden());
+
+        ConductRecord stillOwnedByOtherStudent = conductRecordRepository.findById(existing.getId()).orElseThrow();
+        org.junit.jupiter.api.Assertions.assertEquals(otherStudent.getId(), stillOwnedByOtherStudent.getStudent().getId());
+        org.junit.jupiter.api.Assertions.assertEquals(ConductRating.TOT, stillOwnedByOtherStudent.getRating());
+    }
+
+    @Test
+    void createConductRecord_evaluatedByNotOwnStaffProfile_returns403() throws Exception {
+        // homeroomTeacher is authorized over the student, but tries to attribute
+        // the evaluation to a different staff member than themselves.
+        mockMvc.perform(post("/v1/conduct")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(conductPayload(student, otherTeacher, ConductRating.TOT, "spoofed evaluator"))
+                        .with(asUser(homeroomTeacherUser, "TEACHER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void updateConductRecord_reassigningToDuplicateStudentSemester_returns409() throws Exception {
+        // record1 = (student, hk1) already exists; record2 = (otherStudent, hk1).
+        // Updating record2 to also target (student, hk1) must be rejected as a
+        // duplicate, not silently violate the unique constraint underneath.
+        conductRecordRepository.save(ConductRecord.builder()
+                .student(student).semester(hk1).rating(ConductRating.TOT)
+                .evaluatedBy(homeroomTeacher).build());
+        ConductRecord record2 = conductRecordRepository.save(ConductRecord.builder()
+                .student(otherStudent).semester(hk1).rating(ConductRating.KHA)
+                .evaluatedBy(otherTeacher).build());
+
+        mockMvc.perform(put("/v1/conduct/{id}", record2.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(conductPayload(student, homeroomTeacher, ConductRating.YEU, "collide"))
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void getStudentConductRecords_asOwner_returns200() throws Exception {
+        conductRecordRepository.save(ConductRecord.builder()
+                .student(student).semester(hk1).rating(ConductRating.TOT)
+                .evaluatedBy(homeroomTeacher).build());
+
+        mockMvc.perform(get("/v1/conduct/student/{studentId}", student.getId())
+                        .with(asUser(studentUser, "STUDENT")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].rating").value("TOT"));
+    }
+
+    @Test
+    void getStudentConductRecords_asDifferentStudent_returns403() throws Exception {
+        mockMvc.perform(get("/v1/conduct/student/{studentId}", student.getId())
+                        .with(asUser(otherStudentUser, "STUDENT")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "TEACHER")
+    void getClassSemesterRoster_showsAllStudentsIncludingUnevaluated() throws Exception {
+        conductRecordRepository.save(ConductRecord.builder()
+                .student(student).semester(hk1).rating(ConductRating.TOT)
+                .evaluatedBy(homeroomTeacher).build());
+
+        SchoolClass homeroomClass = schoolClassRepository
+                .findByClassNameAndSection("ITEST-COND-10", "A").orElseThrow();
+
+        mockMvc.perform(get("/v1/conduct/class/{classId}/semester/{semesterId}",
+                        homeroomClass.getId(), hk1.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].studentId").value(student.getId()))
+                .andExpect(jsonPath("$[0].rating").value("TOT"));
+    }
+
+    @Test
+    @WithMockUser(roles = "STUDENT")
+    void getClassSemesterRoster_asStudent_returns403() throws Exception {
+        SchoolClass homeroomClass = schoolClassRepository
+                .findByClassNameAndSection("ITEST-COND-10", "A").orElseThrow();
+
+        mockMvc.perform(get("/v1/conduct/class/{classId}/semester/{semesterId}",
+                        homeroomClass.getId(), hk1.getId()))
+                .andExpect(status().isForbidden());
+    }
+}


### PR DESCRIPTION
New module: /v1/conduct - one ConductRecord per (student, semester), rating enum TOT/KHA/TRUNG_BINH/YEU, per IMPLEMENTATION_PLAN.md 3.4.

Entity/API: ConductRecord (student, semester, rating, remarks, evaluatedBy Staff), migration V6__conduct_records.sql (unique constraint on student+semester, no backfill/seed data - nothing pre-3.4 represented this).

Endpoints:
- POST/PUT /v1/conduct (ADMIN/TEACHER)
- GET /v1/conduct/student/{id} (ADMIN/TEACHER/STUDENT - self only for STUDENT)
- GET /v1/conduct/class/{classId}/semester/{semesterId} (ADMIN/TEACHER) - bulk roster table for GVCN: one row per student in the class, null rating/remarks for students not yet evaluated this semester.

Permission model (per the plan's explicit requirement): a TEACHER may only write conduct for students in a class they are GVCN (classTeacher) of; ADMIN is unrestricted. A STUDENT may only read their own records (same object-level pattern established in GradeRecordService/3.3).

Self-reviewed with the code-review skill before committing (same practice just applied to 3.3) and fixed everything it found:
- updateConductRecord authorized against the REQUEST's new student only, so a homeroom teacher could "hijack" another GVCN's existing record by reassigning it to their own student and passing the check. Now authorizes against both the record's original student (first) and the target student (second) - a teacher must already be allowed to touch the record before being allowed to move it anywhere.
- The original homeroom check resolved "the student's class" via schoolClassRepository.findByClassNameAndSection(...), a single-result Optional query, but (className, section) isn't unique across academic years - could throw IncorrectResultSizeDataAccessException (masked 500). Reworked to check "does this teacher's list of homeroom classes (findByClassTeacher, a List) include one matching the student's className/section" instead - no ambiguity-crash risk.
- evaluatedBy was accepted verbatim from the request with no check that it matched the caller's own staff profile, letting a TEACHER attribute an evaluation to a different staff member. Now enforced: a TEACHER's evaluatedBy must equal their own resolved Staff id.
- createConductRecord/updateConductRecord had the same exists()-then-save() TOCTOU race already fixed in GradeComponentConfigService (3.3 review) - a losing concurrent request would hit the DB unique constraint and surface as a masked 500. Both now catch DataIntegrityViolationException and rethrow as DuplicateResourceException (409); updateConductRecord also gets an explicit pre-check when the update changes the (student, semester) key.
- getClassSemesterRoster's roster-membership lookup shares the same (deprecated, not year-scoped) className/section convention SchoolClassService.getStudentsInClass already uses codebase-wide - documented as a known, pre-existing limitation (not fixed here; a real fix means wiring up Student.currentClass everywhere, which no code path currently maintains on write) rather than inventing a different, inconsistent roster mechanism for just this one endpoint.

Reused util.EntityResolver (from the 3.3 review fix) for all four FK-reference resolutions instead of duplicating resolveX() methods again.

Live-verified against local MySQL/Tomcat (port 8081) using real JWTs and the seeded dev accounts (admin/teacher1/teacher2/student1):
- Assigned teacher1 as GVCN of 10-A via the existing PUT /v1/classes/{id}/teacher/{staffId} endpoint (discovered along the way that PUT /v1/classes/{id} silently ignores classTeacher in the request body - a pre-existing SchoolClassService.updateClass gap, not touched here since it's out of this phase's scope).
- teacher1 (GVCN of 10-A) creating conduct for a 10-A student -> 201.
- teacher2 (GVCN of 10-B, NOT 10-A) creating conduct for a 10-A student -> 403.
- Duplicate create for the same student+semester -> 409.
- Hijack attempt: teacher1 tried to PUT-reassign teacher2's existing record (for a 10-B student) onto their own 10-A student -> 403, and the record was confirmed unchanged afterward (still owned by the original 10-B student, original rating).
- evaluatedBy spoofing: teacher1 creating conduct for their own student but with evaluatedBy set to teacher2's staff id -> 403; the same request with evaluatedBy set to their own staff id -> 201.
- Bulk roster GET for 10-A/semester showed the evaluated student with their rating and the other two students with null rating/remarks.
- student1 reading their own conduct -> 200; reading another student's -> 403.
- STUDENT calling the class-roster endpoint -> 403 (ADMIN/TEACHER only).
- Cleaned up all test-created rows and classTeacher assignments afterward (conduct_records back to 0 rows, classes.class_teacher_id back to NULL).

New ConductRecordIntegrationTest (14 tests, real Spring context + local MySQL, @Transactional rollback), following the same asUser() pattern established in GradeRecordIntegrationTest (the controller casts authentication.getPrincipal() to our User, which @WithMockUser's principal isn't).

Full suite: 68/68 passing (54 pre-existing + 14 new) against local MySQL.

README: added the Conduct module row, V6 migration entry, the GVCN write-permission note under Object-level authorization, Future enhancements updated (3.4 marked done) with a note on the roster's known className/section limitation.