### PR TITLE
Phase 3.5: Xet len lop / O lai / Tot nghiep (promotion records)

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -45,6 +45,8 @@ http://localhost:8080/api/swagger-ui.html
 | Grade Records | `/v1/grade-records/*` | Điểm theo Thông tư 22/2021 — thang điểm 10, per component type (miệng/15p/1 tiết/giữa kỳ/cuối kỳ); supersedes Grades above. Điểm TB học kỳ/cả năm per subject via `/student/{id}/summary` and `/student/{id}/year-summary` |
 | Grade Config | `/v1/grade-config/*` | ADMIN-only: hệ số (weight) per component type, scoped by the academic year it starts applying from |
 | Conduct (Hạnh kiểm) | `/v1/conduct/*` | Đánh giá hạnh kiểm/rèn luyện theo học kỳ (TOT/KHA/TRUNG_BINH/YEU), one per student per semester. TEACHER may only write for students in the class they are GVCN of; class/semester roster view for bulk entry |
+| Promotion Thresholds | `/v1/promotion-thresholds/*` | ADMIN/PRINCIPAL-only: cutoffs (điểm TB môn thấp nhất, hạnh kiểm tối thiểu, tỷ lệ nghỉ tối đa) used to suggest xét lên lớp decisions, scoped by academic year |
+| Promotions (Xét lên lớp) | `/v1/promotions/*` | Xét lên lớp/ở lại/tốt nghiệp — live preview per class (not persisted) + `POST /confirm` to save the final decision (bulk, overwrite-on-reconfirm). ADMIN/PRINCIPAL confirm; ADMIN/PRINCIPAL/TEACHER can preview |
 | Fees | `/v1/fees/*` | Student fees & payments |
 | Library | `/v1/library/*` | Book catalog & borrowing |
 | Dashboard | `/v1/dashboard/stats` | Admin summary stats |
@@ -59,6 +61,7 @@ See [Swagger UI](http://localhost:8080/api/swagger-ui.html) for the full, curren
 - `V4__teaching_timetable.sql` added `TeachingAssignment`/`TimetableSlot` (no backfill — nothing pre-3.2 represented this data).
 - `V5__grading_tt22.sql` added `grade_records`/`grade_component_configs` (Thông tư 22/2021 grading). No backfill from the old `grades` table — the two scoring models (percentage-of-total vs. thang điểm 10 by component type) don't map onto each other automatically — and no default weight rows are seeded; an ADMIN must configure them via `POST /v1/grade-config` before anyone can enter grades.
 - `V6__conduct_records.sql` added `conduct_records` (hạnh kiểm/rèn luyện), one row per (student, semester) enforced by a unique constraint. No backfill — nothing pre-3.4 represented this data.
+- `V7__promotion_records.sql` added `promotion_threshold_configs` (no default rows — an ADMIN/PRINCIPAL must configure cutoffs via `POST /v1/promotion-thresholds` before any suggestion can be computed) and `promotion_records` (one row per student per academic year, unique constraint enforced). No backfill.
 - Create the database once:
   ```sql
   CREATE DATABASE school_management CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -99,7 +102,7 @@ Nothing is hard-coded — everything sensitive comes from environment variables 
 - To create an account with any other role, an authenticated **ADMIN** calls `POST /v1/users` with an explicit `role`.
 
 ### Object-level authorization (own-record access)
-Endpoints scoped to `{studentId}` in the path/query (currently: `/v1/grade-records/student/*`, `/v1/grade-records/{id}`, `/v1/conduct/student/{id}`) additionally check, for a caller with the `STUDENT` role only, that the id being requested is their own — a student cannot read another student's grades/conduct by id even though `hasRole('STUDENT')` alone would pass. `ADMIN`/`TEACHER` callers are unrestricted. This check isn't yet applied to the older Grades/Fees/Attendance modules (Phase 1-2), which currently authorize `STUDENT` by role only.
+Endpoints scoped to `{studentId}` in the path/query (currently: `/v1/grade-records/student/*`, `/v1/grade-records/{id}`, `/v1/conduct/student/{id}`, `/v1/promotions/student/{id}`) additionally check, for a caller with the `STUDENT` role only, that the id being requested is their own — a student cannot read another student's grades/conduct/promotion decisions by id even though `hasRole('STUDENT')` alone would pass. `ADMIN`/`TEACHER`/`PRINCIPAL` callers are unrestricted. This check isn't yet applied to the older Grades/Fees/Attendance modules (Phase 1-2), which currently authorize `STUDENT` by role only.
 
 `/v1/conduct` additionally enforces a GVCN (homeroom-teacher) check on writes: a `TEACHER` may only create/update a conduct record for a student in a class they are `classTeacher` of, and may only submit it under their own staff profile (`evaluatedBy` must match). `ADMIN` is unrestricted. Updating an existing record re-checks this against *both* the record's current student and the (possibly different) target student, so a teacher can't "steal" another GVCN's record by reassigning it to their own class.
 
@@ -191,8 +194,10 @@ backend/
 
 ## 🚀 Future enhancements
 
-See the "Giai đoạn 3" section of [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) for the full roadmap — promotion workflow (xét lên lớp/ở lại/tốt nghiệp), parent portal & sổ liên lạc điện tử, admissions, PDF/Excel reports, audit log. (3.1 Năm học/Học kỳ/Môn học, 3.2 Phân công giảng dạy & Thời khoá biểu, 3.3 Điểm theo TT22 — điểm TB formulas + entity/API framework, and 3.4 Hạnh kiểm/Rèn luyện are done, above.)
+See the "Giai đoạn 3" section of [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) for the full roadmap — parent portal & sổ liên lạc điện tử, admissions, PDF/Excel reports, audit log. (3.1 Năm học/Học kỳ/Môn học, 3.2 Phân công giảng dạy & Thời khoá biểu, 3.3 Điểm theo TT22, 3.4 Hạnh kiểm/Rèn luyện, and 3.5 Xét lên lớp/Ở lại/Tốt nghiệp are done, above.)
 
 **Note on 3.3**: `GradeClassification` (xếp loại học lực: Tốt/Giỏi/Khá/Đạt/Trung bình/Yếu/Chưa đạt/Kém) exists as vocabulary and the DTOs carry a `classification` field, but the actual TT22/58 threshold logic is **not implemented** — it's deliberately deferred pending confirmation from someone with education-domain expertise on the exact score cutoffs and the môn Toán/Ngữ văn condition. The field is always `null` (omitted from JSON) until that's implemented.
 
 **Note on 3.4**: the class/semester roster (`GET /v1/conduct/class/{classId}/semester/{semesterId}`) matches students to a class via the same (deprecated) `className`/`section` string pair `SchoolClassService.getStudentsInClass` already uses codebase-wide — not scoped by academic year, so a reused className/section across years could over-match. Pre-existing limitation of that roster convention (Phase 1-2), not new to this endpoint; a real fix means wiring up `Student.currentClass` (the FK meant to replace it) everywhere roster membership is checked, which no code path currently maintains on write.
+
+**Note on 3.5**: `PromotionThresholdConfig`'s `minSubjectAverage` is compared against the *lowest* of a student's per-subject điểm TB năm (not an invented cross-subject blended average) precisely because xếp loại học lực isn't computed yet (see 3.3 note) — TT22/58 define promotion criteria per-subject-plus-conditions, not one overall number, so this is a configurable approximation of the real criteria, not the official calculation. `previewClassPromotions` does one grade/conduct/attendance lookup per roster student (no batching) — fine for a class-sized roster, would need work to scale to a whole-school report.

--- a/backend/src/main/java/com/schoolmanagement/controller/PromotionController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/PromotionController.java
@@ -1,0 +1,54 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.dto.PromotionPreviewEntryDTO;
+import com.schoolmanagement.dto.PromotionRecordDTO;
+import com.schoolmanagement.entity.PromotionRecord;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.service.PromotionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/promotions")
+@AllArgsConstructor
+@Tag(name = "Promotions (Xét lên lớp)", description = "Xét lên lớp/ở lại/tốt nghiệp cuối năm. Preview is a live, unsaved suggestion computed from PromotionThresholdConfig; only /confirm persists a decision.")
+public class PromotionController {
+
+    private PromotionService promotionService;
+
+    @GetMapping("/class/{classId}/preview")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER')")
+    @Operation(summary = "Bảng đề xuất xét lên lớp cho cả lớp",
+            description = "One row per student in the class — not persisted. suggestedDecision is null if no PromotionThresholdConfig applies to this academic year yet.")
+    public ResponseEntity<List<PromotionPreviewEntryDTO>> previewClassPromotions(
+            @PathVariable Long classId, @RequestParam Long academicYearId) {
+        return new ResponseEntity<>(promotionService.previewClassPromotions(classId, academicYearId), HttpStatus.OK);
+    }
+
+    @PostMapping("/confirm")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Lưu quyết định xét lên lớp cuối cùng (hỗ trợ ghi đè hàng loạt)",
+            description = "Each entry is a PromotionRecord {student, academicYear, decision, decidedBy, remarks}. Confirming again for the same (student, academicYear) overwrites the previous decision. decisionDate is always set server-side to today, regardless of what's sent.")
+    public ResponseEntity<List<PromotionRecordDTO>> confirmPromotions(@Valid @RequestBody List<PromotionRecord> requests) {
+        return new ResponseEntity<>(promotionService.confirmPromotions(requests), HttpStatus.OK);
+    }
+
+    @GetMapping("/student/{studentId}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'PRINCIPAL', 'TEACHER', 'STUDENT')")
+    @Operation(summary = "Get every confirmed promotion decision for a student (all academic years)",
+            description = "A STUDENT caller may only fetch their own records (403 otherwise).")
+    public ResponseEntity<List<PromotionRecordDTO>> getStudentPromotionHistory(
+            @PathVariable Long studentId, Authentication authentication) {
+        User requester = (User) authentication.getPrincipal();
+        return new ResponseEntity<>(promotionService.getStudentPromotionHistory(studentId, requester), HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/controller/PromotionThresholdController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/PromotionThresholdController.java
@@ -1,0 +1,61 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.dto.PromotionThresholdConfigDTO;
+import com.schoolmanagement.entity.PromotionThresholdConfig;
+import com.schoolmanagement.service.PromotionThresholdConfigService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/promotion-thresholds")
+@AllArgsConstructor
+@Tag(name = "Promotion Thresholds", description = "ADMIN/PRINCIPAL-configurable cutoffs (điểm TB môn thấp nhất, hạnh kiểm tối thiểu, tỷ lệ nghỉ tối đa) used to suggest xét lên lớp decisions, scoped by the academic year they start applying from.")
+public class PromotionThresholdController {
+
+    private PromotionThresholdConfigService promotionThresholdConfigService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Create a promotion threshold config")
+    public ResponseEntity<PromotionThresholdConfigDTO> createConfig(@Valid @RequestBody PromotionThresholdConfig config) {
+        return new ResponseEntity<>(promotionThresholdConfigService.createConfig(config), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Update a promotion threshold config")
+    public ResponseEntity<PromotionThresholdConfigDTO> updateConfig(
+            @PathVariable Long id, @Valid @RequestBody PromotionThresholdConfig details) {
+        return new ResponseEntity<>(promotionThresholdConfigService.updateConfig(id, details), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Get a promotion threshold config by ID")
+    public ResponseEntity<PromotionThresholdConfigDTO> getConfigById(@PathVariable Long id) {
+        return new ResponseEntity<>(promotionThresholdConfigService.getConfigById(id), HttpStatus.OK);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Get all promotion threshold configs")
+    public ResponseEntity<List<PromotionThresholdConfigDTO>> getAllConfigs() {
+        return new ResponseEntity<>(promotionThresholdConfigService.getAllConfigs(), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
+    @Operation(summary = "Delete a promotion threshold config")
+    public ResponseEntity<Void> deleteConfig(@PathVariable Long id) {
+        promotionThresholdConfigService.deleteConfig(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/PromotionPreviewEntryDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/PromotionPreviewEntryDTO.java
@@ -1,0 +1,43 @@
+package com.schoolmanagement.dto;
+
+import com.schoolmanagement.entity.ConductRating;
+import com.schoolmanagement.entity.PromotionDecision;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Schema(description = "One student's xét lên lớp preview row — computed live, not yet saved. Nothing here is persisted until POST /v1/promotions/confirm.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PromotionPreviewEntryDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long studentId;
+    private String studentName;
+    private String rollNumber;
+
+    @Schema(description = "The lowest of the student's per-subject điểm TB năm — null if they have no grade records at all this year")
+    private Double lowestSubjectAverage;
+
+    @Schema(description = "The student's HK2 hạnh kiểm rating — null if not yet evaluated")
+    private ConductRating conduct;
+
+    @Schema(description = "% of recorded school days present this year — null if no attendance was recorded")
+    private Double attendanceRate;
+
+    @Schema(description = "null if no PromotionThresholdConfig applies to this academic year yet")
+    private Boolean meetsThresholds;
+
+    @Schema(description = "A suggestion only (LEN_LOP/O_LAI/TOT_NGHIEP) — null if no threshold config applies yet. RA_TRUONG is never suggested; the final decision is always chosen by a human at confirm time.")
+    private PromotionDecision suggestedDecision;
+
+    @Schema(description = "Human-readable notes — why thresholds aren't met, or why no threshold config applies yet. Empty when the student meets every threshold.")
+    private List<String> reasons;
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/PromotionRecordDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/PromotionRecordDTO.java
@@ -1,0 +1,38 @@
+package com.schoolmanagement.dto;
+
+import com.schoolmanagement.entity.ConductRating;
+import com.schoolmanagement.entity.PromotionDecision;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Schema(description = "A confirmed xét lên lớp/ở lại/tốt nghiệp decision for one student, one academic year.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PromotionRecordDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private Long studentId;
+    private String studentName;
+    private Long academicYearId;
+    private String academicYearName;
+    private Double lowestSubjectAverageSnapshot;
+    private ConductRating conductSnapshot;
+    private Double attendanceRateSnapshot;
+    private PromotionDecision decision;
+    private LocalDate decisionDate;
+    private Long decidedById;
+    private String decidedByName;
+    private String remarks;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/PromotionThresholdConfigDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/PromotionThresholdConfigDTO.java
@@ -1,0 +1,36 @@
+package com.schoolmanagement.dto;
+
+import com.schoolmanagement.entity.ConductRating;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Schema(description = "Ngưỡng xét lên lớp áp dụng từ một năm học trở đi — ADMIN/PRINCIPAL cấu hình qua /v1/promotion-thresholds.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PromotionThresholdConfigDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+
+    @Schema(example = "2025-2026")
+    private String appliesFrom;
+
+    @Schema(description = "No subject's điểm TB năm may fall below this", example = "5.0")
+    private Double minSubjectAverage;
+
+    private ConductRating minConduct;
+
+    @Schema(description = "Max % of recorded school days absent still allowed", example = "20.0")
+    private Double maxAbsenceRate;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/PromotionDecision.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/PromotionDecision.java
@@ -1,0 +1,15 @@
+package com.schoolmanagement.entity;
+
+/**
+ * Quyết định xét lên lớp/ở lại/tốt nghiệp cuối năm học, per
+ * IMPLEMENTATION_PLAN.md 3.5. Always a human (Hội đồng/ADMIN/PRINCIPAL)
+ * decision recorded via POST /v1/promotions/confirm — the system only ever
+ * offers LEN_LOP/O_LAI/TOT_NGHIEP as a *suggestion* (see PromotionService);
+ * RA_TRUONG (rời trường — chuyển trường, thôi học...) is never auto-suggested.
+ */
+public enum PromotionDecision {
+    LEN_LOP,
+    O_LAI,
+    TOT_NGHIEP,
+    RA_TRUONG
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/PromotionRecord.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/PromotionRecord.java
@@ -1,0 +1,93 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * A recorded xét lên lớp/ở lại/tốt nghiệp decision for one student, one
+ * academic year — per IMPLEMENTATION_PLAN.md 3.5. One per (student,
+ * academicYear); confirming again overwrites the previous decision
+ * ("hỗ trợ ghi đè hàng loạt" per the plan).
+ *
+ * The *Snapshot fields freeze the data the decision was based on at
+ * confirm time — later grade/conduct/attendance corrections must not
+ * silently change a decision already made.
+ */
+@Entity
+@Table(name = "promotion_records", uniqueConstraints = @UniqueConstraint(
+        name = "uk_promotion_student_year", columnNames = {"student_id", "academic_year_id"}))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PromotionRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "academic_year_id", nullable = false)
+    private AcademicYear academicYear;
+
+    /** null if the student had no grade records at all for the year. */
+    @Column(name = "lowest_subject_average_snapshot")
+    private Double lowestSubjectAverageSnapshot;
+
+    /** null if the student had no HK2 conduct record. */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "conduct_snapshot")
+    private ConductRating conductSnapshot;
+
+    /** null if the student had no attendance records for the year. Percentage present, 0-100. */
+    @Column(name = "attendance_rate_snapshot")
+    private Double attendanceRateSnapshot;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PromotionDecision decision;
+
+    /**
+     * Always set server-side to today's date at confirm time (see
+     * PromotionService) — never trust a client-supplied decision date, so no
+     * {@code @NotNull} here: the confirm request doesn't need to (and can't
+     * usefully) provide one.
+     */
+    @Column(name = "decision_date", nullable = false)
+    private LocalDate decisionDate;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "decided_by_id", nullable = false)
+    private Staff decidedBy;
+
+    @Column(columnDefinition = "TEXT")
+    private String remarks;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/PromotionThresholdConfig.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/PromotionThresholdConfig.java
@@ -1,0 +1,80 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Ngưỡng xét lên lớp, scoped by the academic year it starts applying from —
+ * ADMIN/PRINCIPAL-configurable (same "no defaults seeded" pattern as
+ * GradeComponentConfig in 3.3, for the same reason: the exact cutoffs are a
+ * regulation/school-policy detail this codebase must not invent).
+ *
+ * Compared against per-subject year averages (the "no subject below X"
+ * floor), not a single invented "overall average across subjects" — TT22/58
+ * define xếp loại per-subject-plus-conditions, not one blended number, and
+ * xếp loại học lực itself is deliberately not computed yet (see
+ * GradeClassification's Javadoc, 3.3). This threshold is therefore a
+ * configurable approximation of the promotion criteria, not the official
+ * xếp loại calculation.
+ */
+@Entity
+@Table(name = "promotion_threshold_configs")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PromotionThresholdConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Academic year name (e.g. "2025-2026") this threshold starts applying from. */
+    @NotBlank
+    @Pattern(regexp = "^\\d{4}-\\d{4}$", message = "appliesFrom must look like a school year, e.g. 2025-2026")
+    @Column(name = "applies_from", nullable = false, unique = true)
+    private String appliesFrom;
+
+    /** No subject's điểm TB năm may fall below this for the student to be considered đạt yêu cầu. */
+    @NotNull
+    @DecimalMin("0.0")
+    @DecimalMax("10.0")
+    @Column(name = "min_subject_average", nullable = false)
+    private Double minSubjectAverage;
+
+    /** Minimum hạnh kiểm rating required (compared by enum declaration order: TOT best, YEU worst). */
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "min_conduct", nullable = false)
+    private ConductRating minConduct;
+
+    /** Maximum % of recorded school days absent, for the year, still allowed. */
+    @NotNull
+    @DecimalMin("0.0")
+    @DecimalMax("100.0")
+    @Column(name = "max_absence_rate", nullable = false)
+    private Double maxAbsenceRate;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at")
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/PromotionRecordRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/PromotionRecordRepository.java
@@ -1,0 +1,16 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.PromotionRecord;
+import com.schoolmanagement.entity.Student;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PromotionRecordRepository extends JpaRepository<PromotionRecord, Long> {
+    Optional<PromotionRecord> findByStudentAndAcademicYear(Student student, AcademicYear academicYear);
+    List<PromotionRecord> findByStudent(Student student);
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/PromotionThresholdConfigRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/PromotionThresholdConfigRepository.java
@@ -1,0 +1,13 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.PromotionThresholdConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PromotionThresholdConfigRepository extends JpaRepository<PromotionThresholdConfig, Long> {
+    Optional<PromotionThresholdConfig> findByAppliesFrom(String appliesFrom);
+    boolean existsByAppliesFrom(String appliesFrom);
+}

--- a/backend/src/main/java/com/schoolmanagement/service/GradeRecordService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/GradeRecordService.java
@@ -22,6 +22,7 @@ import com.schoolmanagement.repository.SemesterRepository;
 import com.schoolmanagement.repository.StaffRepository;
 import com.schoolmanagement.repository.StudentRepository;
 import com.schoolmanagement.repository.SubjectRepository;
+import com.schoolmanagement.util.AcademicYearMatcher;
 import com.schoolmanagement.util.EntityResolver;
 import lombok.AllArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
@@ -229,24 +230,16 @@ public class GradeRecordService {
 
     /** Weight in effect for componentType as of academicYearName — the config with the latest appliesFrom <= academicYearName. */
     private int resolveWeight(GradeComponentType componentType, String academicYearName) {
-        int targetYear = extractStartYear(academicYearName);
+        int targetYear = AcademicYearMatcher.extractStartYear(academicYearName);
 
         return gradeComponentConfigRepository.findByComponentType(componentType).stream()
-                .filter(config -> extractStartYear(config.getAppliesFrom()) <= targetYear)
-                .max(Comparator.comparingInt(config -> extractStartYear(config.getAppliesFrom())))
+                .filter(config -> AcademicYearMatcher.extractStartYear(config.getAppliesFrom()) <= targetYear)
+                .max(Comparator.comparingInt(config -> AcademicYearMatcher.extractStartYear(config.getAppliesFrom())))
                 .map(GradeComponentConfig::getWeight)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "No grade-component weight configured for " + componentType
                                 + " applicable to academic year " + academicYearName
                                 + " — set one via POST /v1/grade-config"));
-    }
-
-    private int extractStartYear(String academicYearLabel) {
-        try {
-            return Integer.parseInt(academicYearLabel.trim().split("-")[0].trim());
-        } catch (Exception ex) {
-            throw new IllegalArgumentException("Cannot parse a starting year out of: " + academicYearLabel);
-        }
     }
 
     private double round2(double value) {

--- a/backend/src/main/java/com/schoolmanagement/service/PromotionService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/PromotionService.java
@@ -1,0 +1,347 @@
+package com.schoolmanagement.service;
+
+import com.schoolmanagement.dto.PromotionPreviewEntryDTO;
+import com.schoolmanagement.dto.PromotionRecordDTO;
+import com.schoolmanagement.dto.SubjectYearAverageDTO;
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.Attendance;
+import com.schoolmanagement.entity.AttendanceStatus;
+import com.schoolmanagement.entity.ConductRating;
+import com.schoolmanagement.entity.ConductRecord;
+import com.schoolmanagement.entity.PromotionDecision;
+import com.schoolmanagement.entity.PromotionRecord;
+import com.schoolmanagement.entity.PromotionThresholdConfig;
+import com.schoolmanagement.entity.Role;
+import com.schoolmanagement.entity.SchoolClass;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.SemesterName;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.Student;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.exception.DuplicateResourceException;
+import com.schoolmanagement.exception.ResourceNotFoundException;
+import com.schoolmanagement.repository.AcademicYearRepository;
+import com.schoolmanagement.repository.AttendanceRepository;
+import com.schoolmanagement.repository.ConductRecordRepository;
+import com.schoolmanagement.repository.PromotionRecordRepository;
+import com.schoolmanagement.repository.PromotionThresholdConfigRepository;
+import com.schoolmanagement.repository.SchoolClassRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import com.schoolmanagement.repository.StaffRepository;
+import com.schoolmanagement.repository.StudentRepository;
+import com.schoolmanagement.util.AcademicYearMatcher;
+import com.schoolmanagement.util.EntityResolver;
+import lombok.AllArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Xét lên lớp/ở lại/tốt nghiệp per IMPLEMENTATION_PLAN.md 3.5.
+ *
+ * The preview's suggestedDecision is a configurable APPROXIMATION, not the
+ * official TT22/58 xếp loại calculation (that classification is deliberately
+ * not implemented yet — see GradeClassification, 3.3). It compares the
+ * student's lowest per-subject điểm TB năm (not an invented cross-subject
+ * average), HK2 hạnh kiểm, and attendance rate against an ADMIN/PRINCIPAL-
+ * configured {@link PromotionThresholdConfig} — no defaults are seeded, so
+ * with no config, no suggestion is offered. The final decision is always
+ * chosen by a human at confirm time; nothing here is authoritative.
+ */
+@Service
+@AllArgsConstructor
+@Transactional
+public class PromotionService {
+
+    /** Lớp 9 (cuối THCS) và lớp 12 (cuối THPT) — students who meet thresholds here are suggested TOT_NGHIEP, not LEN_LOP. */
+    private static final Set<Integer> GRADUATING_GRADE_LEVELS = Set.of(9, 12);
+
+    private PromotionRecordRepository promotionRecordRepository;
+    private PromotionThresholdConfigRepository promotionThresholdConfigRepository;
+    private StudentRepository studentRepository;
+    private AcademicYearRepository academicYearRepository;
+    private SchoolClassRepository schoolClassRepository;
+    private SemesterRepository semesterRepository;
+    private ConductRecordRepository conductRecordRepository;
+    private AttendanceRepository attendanceRepository;
+    private StaffRepository staffRepository;
+    private GradeRecordService gradeRecordService;
+
+    /**
+     * Bảng xét lên lớp cho cả lớp — computed live, nothing here is saved yet.
+     * Does one grade/conduct/attendance lookup per roster student (no
+     * findByStudentIn-style batching) — acceptable for a class-sized roster
+     * (tens of students), but would need batching to scale to a whole-school
+     * report across many classes at once.
+     */
+    public List<PromotionPreviewEntryDTO> previewClassPromotions(Long classId, Long academicYearId) {
+        SchoolClass schoolClass = schoolClassRepository.findById(classId)
+                .orElseThrow(() -> new ResourceNotFoundException("Class not found with id: " + classId));
+        AcademicYear academicYear = academicYearRepository.findById(academicYearId)
+                .orElseThrow(() -> new ResourceNotFoundException("Academic year not found with id: " + academicYearId));
+
+        // The same className/section can exist across multiple academic years
+        // (SchoolClass's own unique constraint is on all three together) - without
+        // this check, a mismatched classId/academicYearId pair would silently mix
+        // one year's roster with another year's grading/attendance window.
+        if (!academicYear.getName().equals(schoolClass.getAcademicYear())) {
+            throw new IllegalArgumentException("Class " + classId + " (" + schoolClass.getClassName() + "-"
+                    + schoolClass.getSection() + ", năm học " + schoolClass.getAcademicYear()
+                    + ") does not belong to academic year " + academicYear.getName());
+        }
+
+        List<Student> roster = studentRepository.findByClassNameAndSection(
+                schoolClass.getClassName(), schoolClass.getSection());
+        Semester hk2 = resolveHk2(academicYear);
+        PromotionThresholdConfig config = resolveThresholdConfig(academicYear.getName()).orElse(null);
+
+        return roster.stream()
+                .map(student -> buildPreviewEntry(student, academicYear, hk2, schoolClass.getGradeLevel(), config))
+                .collect(Collectors.toList());
+    }
+
+    public List<PromotionRecordDTO> confirmPromotions(List<PromotionRecord> requests) {
+        return requests.stream().map(this::confirmOne).collect(Collectors.toList());
+    }
+
+    public List<PromotionRecordDTO> getStudentPromotionHistory(Long studentId, User requester) {
+        enforceOwnStudentAccess(studentId, requester);
+        Student student = studentRepository.findById(studentId)
+                .orElseThrow(() -> new ResourceNotFoundException("Student not found with id: " + studentId));
+
+        return promotionRecordRepository.findByStudent(student)
+                .stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    private PromotionRecordDTO confirmOne(PromotionRecord request) {
+        Student student = resolveStudent(request.getStudent());
+        AcademicYear academicYear = resolveAcademicYear(request.getAcademicYear());
+        // Unlike ConductRecordService's evaluatedBy (pinned to the caller's own
+        // staff profile for TEACHER writes, since /v1/conduct is open to any
+        // TEACHER), decidedBy here is accepted as given: /v1/promotions/confirm
+        // is already ADMIN/PRINCIPAL-only, and a xét lên lớp decision is
+        // recorded "on behalf of" a Hội đồng — the ADMIN/PRINCIPAL confirming
+        // it often isn't the staff member of record themselves (and ADMIN
+        // accounts aren't required to have a Staff profile at all).
+        Staff decidedBy = resolveStaff(request.getDecidedBy());
+        if (request.getDecision() == null) {
+            throw new IllegalArgumentException("decision is required");
+        }
+
+        Double lowestSubjectAverage = computeLowestSubjectAverage(student, academicYear);
+        Semester hk2 = resolveHk2(academicYear);
+        ConductRating conduct = resolveConduct(student, hk2);
+        Double attendanceRate = computeAttendanceRate(student, academicYear);
+
+        // Ghi đè hàng loạt: confirming again for the same (student, academicYear)
+        // updates the existing decision rather than erroring.
+        PromotionRecord record = promotionRecordRepository
+                .findByStudentAndAcademicYear(student, academicYear)
+                .orElseGet(PromotionRecord::new);
+
+        record.setStudent(student);
+        record.setAcademicYear(academicYear);
+        record.setLowestSubjectAverageSnapshot(lowestSubjectAverage);
+        record.setConductSnapshot(conduct);
+        record.setAttendanceRateSnapshot(attendanceRate);
+        record.setDecision(request.getDecision());
+        record.setDecisionDate(LocalDate.now());
+        record.setDecidedBy(decidedBy);
+        record.setRemarks(request.getRemarks());
+
+        try {
+            return mapToDTO(promotionRecordRepository.save(record));
+        } catch (DataIntegrityViolationException ex) {
+            // Two concurrent confirms for the same brand-new (student, year) pair
+            // can both miss the findByStudentAndAcademicYear lookup above before
+            // either commits; surface that race as 409, not a masked 500.
+            throw new DuplicateResourceException(
+                    "A promotion decision for this student and academic year was just confirmed by another request — retry");
+        }
+    }
+
+    private PromotionPreviewEntryDTO buildPreviewEntry(Student student, AcademicYear academicYear, Semester hk2,
+                                                         Integer gradeLevel, PromotionThresholdConfig config) {
+        Double lowestSubjectAverage = computeLowestSubjectAverage(student, academicYear);
+        ConductRating conduct = resolveConduct(student, hk2);
+        Double attendanceRate = computeAttendanceRate(student, academicYear);
+
+        List<String> reasons = new ArrayList<>();
+        Boolean meetsThresholds = null;
+        PromotionDecision suggestedDecision = null;
+
+        if (config == null) {
+            reasons.add("Chưa cấu hình ngưỡng xét lên lớp cho năm học này — xem POST /v1/promotion-thresholds");
+        } else {
+            meetsThresholds = true;
+
+            if (lowestSubjectAverage == null) {
+                meetsThresholds = false;
+                reasons.add("Chưa có điểm môn nào để xét");
+            } else if (lowestSubjectAverage < config.getMinSubjectAverage()) {
+                meetsThresholds = false;
+                reasons.add("Có môn điểm TB năm (" + lowestSubjectAverage + ") dưới ngưỡng " + config.getMinSubjectAverage());
+            }
+
+            if (conduct == null) {
+                meetsThresholds = false;
+                reasons.add("Chưa có đánh giá hạnh kiểm học kỳ 2");
+            } else if (conduct.ordinal() > config.getMinConduct().ordinal()) {
+                meetsThresholds = false;
+                reasons.add("Hạnh kiểm (" + conduct + ") dưới ngưỡng " + config.getMinConduct());
+            }
+
+            if (attendanceRate == null) {
+                meetsThresholds = false;
+                reasons.add("Chưa có dữ liệu điểm danh");
+            } else if ((100.0 - attendanceRate) > config.getMaxAbsenceRate()) {
+                meetsThresholds = false;
+                reasons.add(String.format("Tỷ lệ nghỉ (%.1f%%) vượt ngưỡng %.1f%%",
+                        100.0 - attendanceRate, config.getMaxAbsenceRate()));
+            }
+
+            if (meetsThresholds) {
+                suggestedDecision = (gradeLevel != null && GRADUATING_GRADE_LEVELS.contains(gradeLevel))
+                        ? PromotionDecision.TOT_NGHIEP
+                        : PromotionDecision.LEN_LOP;
+            } else {
+                suggestedDecision = PromotionDecision.O_LAI;
+            }
+        }
+
+        return PromotionPreviewEntryDTO.builder()
+                .studentId(student.getId())
+                .studentName(studentName(student))
+                .rollNumber(student.getRollNumber())
+                .lowestSubjectAverage(lowestSubjectAverage)
+                .conduct(conduct)
+                .attendanceRate(attendanceRate)
+                .meetsThresholds(meetsThresholds)
+                .suggestedDecision(suggestedDecision)
+                .reasons(reasons)
+                .build();
+    }
+
+    /** The lowest of the student's per-subject điểm TB năm — null if there are none. */
+    private Double computeLowestSubjectAverage(Student student, AcademicYear academicYear) {
+        // requester=null: this is an internal, already-authorized call (the
+        // controller's own @PreAuthorize already restricted the caller to
+        // ADMIN/PRINCIPAL/TEACHER) — GradeRecordService's own STUDENT-only
+        // ownership check is a no-op for anyone else, so null is safe here.
+        List<SubjectYearAverageDTO> yearSummary =
+                gradeRecordService.getStudentYearSummary(student.getId(), academicYear.getId(), null);
+
+        return yearSummary.stream()
+                .map(SubjectYearAverageDTO::getYearAverage)
+                .filter(Objects::nonNull)
+                .min(Double::compareTo)
+                .orElse(null);
+    }
+
+    private ConductRating resolveConduct(Student student, Semester hk2) {
+        if (hk2 == null) {
+            return null;
+        }
+        return conductRecordRepository.findByStudentAndSemester(student, hk2)
+                .map(ConductRecord::getRating)
+                .orElse(null);
+    }
+
+    /** % of recorded school days NOT marked ABSENT, for the year — null if nothing was recorded. */
+    private Double computeAttendanceRate(Student student, AcademicYear academicYear) {
+        List<Attendance> records = attendanceRepository.findByStudentAndAttendanceDateBetween(
+                student, academicYear.getStartDate(), academicYear.getEndDate());
+        if (records.isEmpty()) {
+            return null;
+        }
+        long absentCount = records.stream().filter(a -> a.getStatus() == AttendanceStatus.ABSENT).count();
+        return round2(100.0 * (records.size() - absentCount) / records.size());
+    }
+
+    private Semester resolveHk2(AcademicYear academicYear) {
+        return semesterRepository.findByAcademicYear(academicYear).stream()
+                .filter(s -> s.getName() == SemesterName.HK2)
+                .findFirst()
+                .orElse(null);
+    }
+
+    /** The threshold config with the latest appliesFrom <= academicYearName, if any. */
+    private Optional<PromotionThresholdConfig> resolveThresholdConfig(String academicYearName) {
+        int targetYear = AcademicYearMatcher.extractStartYear(academicYearName);
+        return promotionThresholdConfigRepository.findAll().stream()
+                .filter(config -> AcademicYearMatcher.extractStartYear(config.getAppliesFrom()) <= targetYear)
+                .max(Comparator.comparingInt(config -> AcademicYearMatcher.extractStartYear(config.getAppliesFrom())));
+    }
+
+    /** Only a STUDENT is restricted, and only to their own id; ADMIN/PRINCIPAL/TEACHER are unrestricted. */
+    private void enforceOwnStudentAccess(Long targetStudentId, User requester) {
+        if (requester == null || requester.getRole() != Role.STUDENT) {
+            return;
+        }
+        Student own = studentRepository.findByUserId(requester.getId())
+                .orElseThrow(() -> new AccessDeniedException("No student profile linked to this account"));
+        if (!own.getId().equals(targetStudentId)) {
+            throw new AccessDeniedException("Students may only access their own promotion records");
+        }
+    }
+
+    private double round2(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+    private Student resolveStudent(Student reference) {
+        return EntityResolver.resolveOrThrow(studentRepository, reference != null ? reference.getId() : null, "Student");
+    }
+
+    private AcademicYear resolveAcademicYear(AcademicYear reference) {
+        return EntityResolver.resolveOrThrow(academicYearRepository, reference != null ? reference.getId() : null, "Academic year");
+    }
+
+    private Staff resolveStaff(Staff reference) {
+        return EntityResolver.resolveOrThrow(staffRepository, reference != null ? reference.getId() : null, "Staff (decidedBy)");
+    }
+
+    private String studentName(Student student) {
+        return student.getUser() != null ? student.getUser().getFirstName() + " " + student.getUser().getLastName() : null;
+    }
+
+    private String staffName(Staff staff) {
+        return staff.getUser() != null ? staff.getUser().getFirstName() + " " + staff.getUser().getLastName() : null;
+    }
+
+    private PromotionRecordDTO mapToDTO(PromotionRecord record) {
+        Student student = record.getStudent();
+        AcademicYear academicYear = record.getAcademicYear();
+        Staff decidedBy = record.getDecidedBy();
+
+        return PromotionRecordDTO.builder()
+                .id(record.getId())
+                .studentId(student.getId())
+                .studentName(studentName(student))
+                .academicYearId(academicYear.getId())
+                .academicYearName(academicYear.getName())
+                .lowestSubjectAverageSnapshot(record.getLowestSubjectAverageSnapshot())
+                .conductSnapshot(record.getConductSnapshot())
+                .attendanceRateSnapshot(record.getAttendanceRateSnapshot())
+                .decision(record.getDecision())
+                .decisionDate(record.getDecisionDate())
+                .decidedById(decidedBy.getId())
+                .decidedByName(staffName(decidedBy))
+                .remarks(record.getRemarks())
+                .createdAt(record.getCreatedAt())
+                .updatedAt(record.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/service/PromotionThresholdConfigService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/PromotionThresholdConfigService.java
@@ -1,0 +1,99 @@
+package com.schoolmanagement.service;
+
+import com.schoolmanagement.dto.PromotionThresholdConfigDTO;
+import com.schoolmanagement.entity.PromotionThresholdConfig;
+import com.schoolmanagement.exception.DuplicateResourceException;
+import com.schoolmanagement.exception.ResourceNotFoundException;
+import com.schoolmanagement.repository.PromotionThresholdConfigRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+@Transactional
+public class PromotionThresholdConfigService {
+
+    private PromotionThresholdConfigRepository promotionThresholdConfigRepository;
+
+    public PromotionThresholdConfigDTO createConfig(PromotionThresholdConfig request) {
+        if (promotionThresholdConfigRepository.existsByAppliesFrom(request.getAppliesFrom())) {
+            throw new DuplicateResourceException(
+                    "A promotion threshold starting " + request.getAppliesFrom() + " already exists");
+        }
+
+        // Build fresh from validated fields only - never save the raw request
+        // body as-is, or a client-supplied "id" would silently overwrite an
+        // unrelated existing row (see GradeComponentConfigService, 3.3 review).
+        PromotionThresholdConfig config = PromotionThresholdConfig.builder()
+                .appliesFrom(request.getAppliesFrom())
+                .minSubjectAverage(request.getMinSubjectAverage())
+                .minConduct(request.getMinConduct())
+                .maxAbsenceRate(request.getMaxAbsenceRate())
+                .build();
+
+        try {
+            return mapToDTO(promotionThresholdConfigRepository.save(config));
+        } catch (DataIntegrityViolationException ex) {
+            throw new DuplicateResourceException(
+                    "A promotion threshold starting " + request.getAppliesFrom() + " already exists");
+        }
+    }
+
+    public PromotionThresholdConfigDTO updateConfig(Long id, PromotionThresholdConfig details) {
+        PromotionThresholdConfig config = promotionThresholdConfigRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Promotion threshold not found with id: " + id));
+
+        boolean changingKey = !config.getAppliesFrom().equals(details.getAppliesFrom());
+        if (changingKey && promotionThresholdConfigRepository.existsByAppliesFrom(details.getAppliesFrom())) {
+            throw new DuplicateResourceException(
+                    "A promotion threshold starting " + details.getAppliesFrom() + " already exists");
+        }
+
+        config.setAppliesFrom(details.getAppliesFrom());
+        config.setMinSubjectAverage(details.getMinSubjectAverage());
+        config.setMinConduct(details.getMinConduct());
+        config.setMaxAbsenceRate(details.getMaxAbsenceRate());
+
+        try {
+            return mapToDTO(promotionThresholdConfigRepository.save(config));
+        } catch (DataIntegrityViolationException ex) {
+            throw new DuplicateResourceException(
+                    "A promotion threshold starting " + details.getAppliesFrom() + " already exists");
+        }
+    }
+
+    public PromotionThresholdConfigDTO getConfigById(Long id) {
+        return mapToDTO(promotionThresholdConfigRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Promotion threshold not found with id: " + id)));
+    }
+
+    public List<PromotionThresholdConfigDTO> getAllConfigs() {
+        return promotionThresholdConfigRepository.findAll()
+                .stream()
+                .map(this::mapToDTO)
+                .collect(Collectors.toList());
+    }
+
+    public void deleteConfig(Long id) {
+        PromotionThresholdConfig config = promotionThresholdConfigRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Promotion threshold not found with id: " + id));
+        promotionThresholdConfigRepository.delete(config);
+    }
+
+    private PromotionThresholdConfigDTO mapToDTO(PromotionThresholdConfig config) {
+        return PromotionThresholdConfigDTO.builder()
+                .id(config.getId())
+                .appliesFrom(config.getAppliesFrom())
+                .minSubjectAverage(config.getMinSubjectAverage())
+                .minConduct(config.getMinConduct())
+                .maxAbsenceRate(config.getMaxAbsenceRate())
+                .createdAt(config.getCreatedAt())
+                .updatedAt(config.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/util/AcademicYearMatcher.java
+++ b/backend/src/main/java/com/schoolmanagement/util/AcademicYearMatcher.java
@@ -1,0 +1,28 @@
+package com.schoolmanagement.util;
+
+/**
+ * Shared helper for the "resolve the config whose appliesFrom year is the
+ * latest one still &lt;= this academic year" pattern used by both
+ * GradeRecordService (hệ số điểm, 3.3) and PromotionService (ngưỡng xét lên
+ * lớp, 3.5) — both parse a leading "-"-delimited year out of an academic
+ * year label like "2025-2026" to compare configs scoped by the year they
+ * start applying from.
+ */
+public final class AcademicYearMatcher {
+
+    private AcademicYearMatcher() {
+    }
+
+    /**
+     * @throws IllegalArgumentException (mapped to 400) if academicYearLabel doesn't
+     *         start with a parseable year — e.g. an academic year name or a
+     *         config's appliesFrom that isn't in "YYYY-..." form.
+     */
+    public static int extractStartYear(String academicYearLabel) {
+        try {
+            return Integer.parseInt(academicYearLabel.trim().split("-")[0].trim());
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Cannot parse a starting year out of: " + academicYearLabel);
+        }
+    }
+}

--- a/backend/src/main/resources/db/migration/V7__promotion_records.sql
+++ b/backend/src/main/resources/db/migration/V7__promotion_records.sql
@@ -1,0 +1,42 @@
+-- =====================================================
+-- Phase 3.5: Xet len lop / O lai / Tot nghiep (promotion records)
+-- =====================================================
+-- No default rows in promotion_threshold_configs: the exact cutoffs are a
+-- regulation/school-policy detail this migration doesn't assume - set them
+-- via POST /v1/promotion-thresholds before previewing/confirming decisions.
+-- No backfill in promotion_records - nothing pre-3.5 represented this data.
+-- =====================================================
+
+CREATE TABLE `promotion_threshold_configs` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `applies_from` varchar(255) NOT NULL,
+  `min_subject_average` double NOT NULL,
+  `min_conduct` enum('TOT','KHA','TRUNG_BINH','YEU') NOT NULL,
+  `max_absence_rate` double NOT NULL,
+  `created_at` datetime(6) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_promotion_threshold_applies_from` (`applies_from`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `promotion_records` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `student_id` bigint NOT NULL,
+  `academic_year_id` bigint NOT NULL,
+  `lowest_subject_average_snapshot` double DEFAULT NULL,
+  `conduct_snapshot` enum('TOT','KHA','TRUNG_BINH','YEU') DEFAULT NULL,
+  `attendance_rate_snapshot` double DEFAULT NULL,
+  `decision` enum('LEN_LOP','O_LAI','TOT_NGHIEP','RA_TRUONG') NOT NULL,
+  `decision_date` date NOT NULL,
+  `decided_by_id` bigint NOT NULL,
+  `remarks` text,
+  `created_at` datetime(6) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_promotion_student_year` (`student_id`, `academic_year_id`),
+  KEY `fk_promotion_academic_year` (`academic_year_id`),
+  KEY `fk_promotion_decided_by` (`decided_by_id`),
+  CONSTRAINT `fk_promotion_student` FOREIGN KEY (`student_id`) REFERENCES `students` (`id`),
+  CONSTRAINT `fk_promotion_academic_year` FOREIGN KEY (`academic_year_id`) REFERENCES `academic_years` (`id`),
+  CONSTRAINT `fk_promotion_decided_by` FOREIGN KEY (`decided_by_id`) REFERENCES `staff` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/src/test/java/com/schoolmanagement/controller/PromotionIntegrationTest.java
+++ b/backend/src/test/java/com/schoolmanagement/controller/PromotionIntegrationTest.java
@@ -1,0 +1,388 @@
+package com.schoolmanagement.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.AcademicYearStatus;
+import com.schoolmanagement.entity.ConductRating;
+import com.schoolmanagement.entity.ConductRecord;
+import com.schoolmanagement.entity.EmploymentStatus;
+import com.schoolmanagement.entity.GradeComponentConfig;
+import com.schoolmanagement.entity.GradeComponentType;
+import com.schoolmanagement.entity.GradeRecord;
+import com.schoolmanagement.entity.PromotionDecision;
+import com.schoolmanagement.entity.PromotionRecord;
+import com.schoolmanagement.entity.PromotionThresholdConfig;
+import com.schoolmanagement.entity.Role;
+import com.schoolmanagement.entity.SchoolClass;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.SemesterName;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.StaffPosition;
+import com.schoolmanagement.entity.Student;
+import com.schoolmanagement.entity.StudentStatus;
+import com.schoolmanagement.entity.Subject;
+import com.schoolmanagement.entity.SubjectCategory;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.repository.AcademicYearRepository;
+import com.schoolmanagement.repository.AttendanceRepository;
+import com.schoolmanagement.repository.ConductRecordRepository;
+import com.schoolmanagement.repository.GradeComponentConfigRepository;
+import com.schoolmanagement.repository.GradeRecordRepository;
+import com.schoolmanagement.repository.PromotionRecordRepository;
+import com.schoolmanagement.repository.PromotionThresholdConfigRepository;
+import com.schoolmanagement.repository.SchoolClassRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import com.schoolmanagement.repository.StaffRepository;
+import com.schoolmanagement.repository.StudentRepository;
+import com.schoolmanagement.repository.SubjectRepository;
+import com.schoolmanagement.repository.UserRepository;
+import com.schoolmanagement.entity.Attendance;
+import com.schoolmanagement.entity.AttendanceStatus;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration test for /v1/promotions and /v1/promotion-thresholds — real
+ * Spring context + local MySQL via the "test" profile. Each test rolls back
+ * (@Transactional). Covers IMPLEMENTATION_PLAN.md 3.5: the preview's
+ * suggestedDecision is a configurable approximation (lowest per-subject
+ * điểm TB năm + HK2 hạnh kiểm + attendance rate vs. an ADMIN-configured
+ * PromotionThresholdConfig), never the official TT22/58 xếp loại.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class PromotionIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private AcademicYearRepository academicYearRepository;
+    @Autowired
+    private SemesterRepository semesterRepository;
+    @Autowired
+    private SchoolClassRepository schoolClassRepository;
+    @Autowired
+    private SubjectRepository subjectRepository;
+    @Autowired
+    private StudentRepository studentRepository;
+    @Autowired
+    private StaffRepository staffRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private GradeComponentConfigRepository gradeComponentConfigRepository;
+    @Autowired
+    private GradeRecordRepository gradeRecordRepository;
+    @Autowired
+    private ConductRecordRepository conductRecordRepository;
+    @Autowired
+    private PromotionThresholdConfigRepository promotionThresholdConfigRepository;
+    @Autowired
+    private PromotionRecordRepository promotionRecordRepository;
+    @Autowired
+    private AttendanceRepository attendanceRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private AcademicYear academicYear;
+    private AcademicYear otherAcademicYear;
+    private Semester hk1;
+    private Semester hk2;
+    private Subject subject;
+    private SchoolClass schoolClass;
+    private Student student;
+    private Staff staff;
+    private User studentUser;
+    private User otherStudentUser;
+
+    @BeforeEach
+    void setUp() {
+        academicYear = academicYearRepository.save(AcademicYear.builder()
+                .name("2099-2100")
+                .startDate(LocalDate.of(2099, 9, 1)).endDate(LocalDate.of(2100, 5, 31))
+                .status(AcademicYearStatus.ACTIVE).build());
+        otherAcademicYear = academicYearRepository.save(AcademicYear.builder()
+                .name("2098-2099")
+                .startDate(LocalDate.of(2098, 9, 1)).endDate(LocalDate.of(2099, 5, 31))
+                .status(AcademicYearStatus.ACTIVE).build());
+
+        hk1 = semesterRepository.save(Semester.builder()
+                .academicYear(academicYear).name(SemesterName.HK1)
+                .startDate(academicYear.getStartDate()).endDate(LocalDate.of(2100, 1, 15)).build());
+        hk2 = semesterRepository.save(Semester.builder()
+                .academicYear(academicYear).name(SemesterName.HK2)
+                .startDate(LocalDate.of(2100, 1, 16)).endDate(academicYear.getEndDate()).build());
+
+        subject = subjectRepository.save(Subject.builder()
+                .code("ITEST-PROMO-SUBJ").name("ITEST Subject").category(SubjectCategory.BAT_BUOC).build());
+
+        // gradeLevel 9 (a graduating grade) so the TOT_NGHIEP-suggestion branch is exercised.
+        schoolClass = schoolClassRepository.save(SchoolClass.builder()
+                .className("ITEST-PROMO-9").section("A").academicYear("2099-2100").gradeLevel(9).build());
+
+        User teacherUser = userRepository.save(User.builder()
+                .username("itest.promo.teacher").email("itest.promo.teacher@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Teacher").role(Role.TEACHER).enabled(true).build());
+        staff = staffRepository.save(Staff.builder()
+                .employeeId("ITEST-PROMO-EMP").user(teacherUser)
+                .position(StaffPosition.TEACHER).status(EmploymentStatus.ACTIVE).build());
+
+        studentUser = userRepository.save(User.builder()
+                .username("itest.promo.student").email("itest.promo.student@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Student").role(Role.STUDENT).enabled(true).build());
+        student = studentRepository.save(Student.builder()
+                .rollNumber("ITEST-PROMO-ROLL").admissionNumber("ITEST-PROMO-ADM")
+                .user(studentUser).status(StudentStatus.ACTIVE)
+                .className(schoolClass.getClassName()).section(schoolClass.getSection())
+                .build());
+
+        otherStudentUser = userRepository.save(User.builder()
+                .username("itest.promo.student2").email("itest.promo.student2@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("StudentTwo").role(Role.STUDENT).enabled(true).build());
+        studentRepository.save(Student.builder()
+                .rollNumber("ITEST-PROMO-ROLL-2").admissionNumber("ITEST-PROMO-ADM-2")
+                .user(otherStudentUser).status(StudentStatus.ACTIVE)
+                .className(schoolClass.getClassName()).section(schoolClass.getSection())
+                .build());
+
+        gradeComponentConfigRepository.save(GradeComponentConfig.builder()
+                .componentType(GradeComponentType.MIENG).weight(1).appliesFrom("2099-2100").build());
+    }
+
+    private RequestPostProcessor asUser(User user, String role) {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                user, null, List.of(new SimpleGrantedAuthority("ROLE_" + role))));
+    }
+
+    private void giveStudentQualifyingRecord() {
+        gradeRecordRepository.save(GradeRecord.builder()
+                .student(student).subject(subject).semester(hk1)
+                .componentType(GradeComponentType.MIENG).score(9.0).teacher(staff).build());
+        gradeRecordRepository.save(GradeRecord.builder()
+                .student(student).subject(subject).semester(hk2)
+                .componentType(GradeComponentType.MIENG).score(9.0).teacher(staff).build());
+        conductRecordRepository.save(ConductRecord.builder()
+                .student(student).semester(hk2).rating(ConductRating.TOT).evaluatedBy(staff).build());
+        // No attendance rows -> attendanceRate stays null -> won't meet thresholds
+        // on its own; individual tests add attendance rows when they need a full pass.
+    }
+
+    private void saveThresholdConfig() {
+        promotionThresholdConfigRepository.save(PromotionThresholdConfig.builder()
+                .appliesFrom("2099-2100").minSubjectAverage(5.0)
+                .minConduct(ConductRating.TRUNG_BINH).maxAbsenceRate(20.0).build());
+    }
+
+    @Test
+    @WithMockUser(roles = "TEACHER")
+    void previewClassPromotions_noThresholdConfig_noSuggestion() throws Exception {
+        mockMvc.perform(get("/v1/promotions/class/{classId}/preview", schoolClass.getId())
+                        .param("academicYearId", academicYear.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].meetsThresholds").doesNotExist())
+                .andExpect(jsonPath("$[0].suggestedDecision").doesNotExist())
+                .andExpect(jsonPath("$[0].reasons[0]").value(org.hamcrest.Matchers.containsString("Chưa cấu hình")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void previewClassPromotions_classAcademicYearMismatch_returns400() throws Exception {
+        mockMvc.perform(get("/v1/promotions/class/{classId}/preview", schoolClass.getId())
+                        .param("academicYearId", otherAcademicYear.getId().toString()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void previewClassPromotions_graduatingGradeMeetsThresholds_suggestsTotNghiep() throws Exception {
+        saveThresholdConfig();
+        giveStudentQualifyingRecord();
+        // 4 present, 1 absent this year -> 80% attendance, exactly at the 20% max-absence threshold.
+        markAttendance(4, 1);
+
+        mockMvc.perform(get("/v1/promotions/class/{classId}/preview", schoolClass.getId())
+                        .param("academicYearId", academicYear.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].studentId").value(student.getId()))
+                .andExpect(jsonPath("$[0].lowestSubjectAverage").value(9.0))
+                .andExpect(jsonPath("$[0].conduct").value("TOT"))
+                .andExpect(jsonPath("$[0].attendanceRate").value(80.0))
+                .andExpect(jsonPath("$[0].meetsThresholds").value(true))
+                .andExpect(jsonPath("$[0].suggestedDecision").value("TOT_NGHIEP"))
+                .andExpect(jsonPath("$[0].reasons").isEmpty());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void previewClassPromotions_belowThreshold_suggestsOLaiWithReasons() throws Exception {
+        saveThresholdConfig();
+        // No grades/conduct/attendance at all for this student.
+        mockMvc.perform(get("/v1/promotions/class/{classId}/preview", schoolClass.getId())
+                        .param("academicYearId", academicYear.getId().toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].meetsThresholds").value(false))
+                .andExpect(jsonPath("$[0].suggestedDecision").value("O_LAI"))
+                .andExpect(jsonPath("$[0].reasons", org.hamcrest.Matchers.hasSize(3)));
+    }
+
+    @Test
+    @WithMockUser(roles = "TEACHER")
+    void confirmPromotions_asTeacher_returns403() throws Exception {
+        mockMvc.perform(post("/v1/promotions/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(List.of(confirmRequest(PromotionDecision.LEN_LOP)))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void confirmPromotions_persistsSnapshotAndDecision() throws Exception {
+        saveThresholdConfig();
+        giveStudentQualifyingRecord();
+        markAttendance(4, 1);
+
+        mockMvc.perform(post("/v1/promotions/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(List.of(confirmRequest(PromotionDecision.TOT_NGHIEP)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].studentId").value(student.getId()))
+                .andExpect(jsonPath("$[0].decision").value("TOT_NGHIEP"))
+                .andExpect(jsonPath("$[0].lowestSubjectAverageSnapshot").value(9.0))
+                .andExpect(jsonPath("$[0].conductSnapshot").value("TOT"))
+                .andExpect(jsonPath("$[0].attendanceRateSnapshot").value(80.0))
+                .andExpect(jsonPath("$[0].decidedById").value(staff.getId()));
+
+        Assertions.assertEquals(1, promotionRecordRepository.findByStudent(student).size());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void confirmPromotions_overwritesExistingDecision_updatesInPlaceNotDuplicated() throws Exception {
+        PromotionRecord existing = promotionRecordRepository.save(PromotionRecord.builder()
+                .student(student).academicYear(academicYear)
+                .decision(PromotionDecision.LEN_LOP).decisionDate(LocalDate.now())
+                .decidedBy(staff).build());
+
+        mockMvc.perform(post("/v1/promotions/confirm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(List.of(confirmRequest(PromotionDecision.O_LAI)))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(existing.getId()))
+                .andExpect(jsonPath("$[0].decision").value("O_LAI"));
+
+        List<PromotionRecord> allForStudent = promotionRecordRepository.findByStudent(student);
+        Assertions.assertEquals(1, allForStudent.size());
+        Assertions.assertEquals(PromotionDecision.O_LAI, allForStudent.get(0).getDecision());
+    }
+
+    @Test
+    void getStudentPromotionHistory_asOwner_returns200() throws Exception {
+        promotionRecordRepository.save(PromotionRecord.builder()
+                .student(student).academicYear(academicYear)
+                .decision(PromotionDecision.LEN_LOP).decisionDate(LocalDate.now())
+                .decidedBy(staff).build());
+
+        mockMvc.perform(get("/v1/promotions/student/{studentId}", student.getId())
+                        .with(asUser(studentUser, "STUDENT")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].decision").value("LEN_LOP"));
+    }
+
+    @Test
+    void getStudentPromotionHistory_asDifferentStudent_returns403() throws Exception {
+        mockMvc.perform(get("/v1/promotions/student/{studentId}", student.getId())
+                        .with(asUser(otherStudentUser, "STUDENT")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createThresholdConfig_duplicateAppliesFrom_returns409() throws Exception {
+        saveThresholdConfig();
+        PromotionThresholdConfig duplicate = PromotionThresholdConfig.builder()
+                .appliesFrom("2099-2100").minSubjectAverage(6.0)
+                .minConduct(ConductRating.KHA).maxAbsenceRate(10.0).build();
+
+        mockMvc.perform(post("/v1/promotion-thresholds")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(duplicate)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void createThresholdConfig_malformedAppliesFrom_returns400() throws Exception {
+        PromotionThresholdConfig bad = PromotionThresholdConfig.builder()
+                .appliesFrom("AY2099").minSubjectAverage(5.0)
+                .minConduct(ConductRating.TRUNG_BINH).maxAbsenceRate(20.0).build();
+
+        mockMvc.perform(post("/v1/promotion-thresholds")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(bad)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "TEACHER")
+    void createThresholdConfig_asTeacher_returns403() throws Exception {
+        PromotionThresholdConfig config = PromotionThresholdConfig.builder()
+                .appliesFrom("2100-2101").minSubjectAverage(5.0)
+                .minConduct(ConductRating.TRUNG_BINH).maxAbsenceRate(20.0).build();
+
+        mockMvc.perform(post("/v1/promotion-thresholds")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(config)))
+                .andExpect(status().isForbidden());
+    }
+
+    private PromotionRecord confirmRequest(PromotionDecision decision) {
+        return PromotionRecord.builder()
+                .student(Student.builder().id(student.getId()).build())
+                .academicYear(AcademicYear.builder().id(academicYear.getId()).build())
+                .decision(decision)
+                .decidedBy(Staff.builder().id(staff.getId()).build())
+                .remarks("itest")
+                .build();
+    }
+
+    private void markAttendance(int presentDays, int absentDays) {
+        LocalDate day = academicYear.getStartDate().plusDays(1);
+        for (int i = 0; i < presentDays; i++) {
+            attendanceRepository.save(Attendance.builder()
+                    .student(student).attendanceDate(day.plusDays(i))
+                    .status(AttendanceStatus.PRESENT).build());
+        }
+        for (int i = 0; i < absentDays; i++) {
+            attendanceRepository.save(Attendance.builder()
+                    .student(student).attendanceDate(day.plusDays(presentDays + i))
+                    .status(AttendanceStatus.ABSENT).build());
+        }
+    }
+}


### PR DESCRIPTION
New module: /v1/promotions and /v1/promotion-thresholds, per IMPLEMENTATION_PLAN.md 3.5.

Business-risk decision (matches the 3.3 precedent - asked rather than guessed): TT22/58 promotion criteria are officially expressed via xep loai hoc luc, which isn't computed yet (deferred in 3.3), and the exact diem/hanh kiem/nghi hoc cutoffs are a regulation/policy detail. Asked the user how to handle the preview's auto-suggestion; chosen approach: ADMIN/PRINCIPAL-configurable thresholds (PromotionThresholdConfig, no defaults seeded - same pattern as GradeComponentConfig in 3.3), applied to data that already exists reliably.

Key design choice beyond what was asked: the threshold compares against the LOWEST of a student's per-subject diem TB nam, not an invented overall/blended average across subjects - TT22/58 define criteria per-subject-plus-conditions, not one blended number, so a cross-subject average would itself have been an uncredentialed formula invention. This floor-based comparison is grounded in the actual regulation shape without needing classification. Documented as an approximation, not the official calculation, in Javadoc/Swagger/README.

Entities: PromotionThresholdConfig (minSubjectAverage, minConduct, maxAbsenceRate, scoped by appliesFrom), PromotionRecord (one per student per academic year, snapshots lowestSubjectAverage/conduct/ attendanceRate frozen at confirm time so later corrections don't silently change a decision already made, decision enum LEN_LOP/O_LAI/ TOT_NGHIEP/RA_TRUONG).

Endpoints:
- GET /v1/promotions/class/{classId}/preview?academicYearId=... (ADMIN/ PRINCIPAL/TEACHER) - live, unsaved suggestion per student in the class: suggests TOT_NGHIEP for graduating grades (9, 12) that meet thresholds, LEN_LOP otherwise, O_LAI if not met, null if no threshold config applies yet. RA_TRUONG is never auto-suggested - always a human choice.
- POST /v1/promotions/confirm (ADMIN/PRINCIPAL only) - persists the final decision, "ghi de hang loat": confirming again for the same (student, academicYear) updates the existing record rather than erroring.
- GET /v1/promotions/student/{id} (+STUDENT, self-only) - decision history, same object-level ownership pattern as 3.3/3.4.
- POST/PUT/GET/DELETE /v1/promotion-thresholds (ADMIN/PRINCIPAL only).

Migration V7__promotion_records.sql: no default threshold rows seeded (ADMIN/PRINCIPAL must configure before any suggestion is computed) and no backfill (nothing pre-3.5 represented this data).

Self-reviewed with the code-review skill before committing (same practice as 3.3/3.4) and fixed what it found:
- previewClassPromotions never verified the requested classId actually belongs to the requested academicYearId - the same className/section can exist across multiple years (SchoolClass's own unique constraint spans all three), so a mismatched pair would silently mix one year's roster with another year's grading/attendance window. Now checks academicYear.name against the class's own academicYear field first and rejects a mismatch with 400. Live-verified: created a second, unrelated academic year and confirmed the mismatched classId/academicYearId combo is rejected before touching any data.
- Documented (not changed) two lower-severity findings: decidedBy is accepted as given rather than pinned to the caller's own staff profile (unlike ConductRecordService's evaluatedBy check) - deliberate, since /confirm is already ADMIN/PRINCIPAL-only and a xet len lop decision is recorded "on behalf of" a Hoi dong, not as one teacher's individual act; and previewClassPromotions does one lookup per roster student (no batching) - fine at class scale, would need work for a whole-school report.
- Extracted the "leading year" parsing (the exact logic that had a real bug fixed in the 3.3 review) into a new shared util.AcademicYearMatcher and switched GradeRecordService's resolveWeight to use it too, instead of introducing a third private copy for PromotionService.

Live-verified against local MySQL/Tomcat (port 8081) with real JWTs and seeded dev accounts: preview with no threshold config shows no suggestion with an explanatory reason; classId/academicYearId mismatch -> 400; created a threshold config (duplicate -> 409, malformed appliesFrom -> 400); gave a student qualifying grades (9.0 MIENG both semesters), HK2 conduct TOT, and attendance (4 present/1 absent = 80%, exactly at the 20% max-absence threshold) -> preview correctly returned meetsThresholds=true, suggestedDecision=LEN_LOP; confirmed it, then re-confirmed with a different decision and verified the SAME record id was updated in place (not duplicated); TEACHER can preview (200) but not confirm or configure thresholds (403 both); STUDENT can read their own promotion history (200) but not another student's (403). Cleaned up all test-created rows afterward.

New PromotionIntegrationTest (12 tests, real Spring context + local MySQL, @Transactional rollback) covering the same scenarios, including the graduating-grade-level (9) TOT_NGHIEP suggestion branch and the ghi-de-hang-loat (overwrite, not duplicate) confirm semantics.

Full suite: 80/80 passing (68 pre-existing + 12 new) against local MySQL.

README: added Promotion Thresholds/Promotions module rows, V7 migration entry, object-level authorization note extended to /v1/promotions/student/{id}, Future enhancements updated (3.5 marked done) with a note on the lowest-subject-average approximation and the preview's per-student lookup cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added promotion and retention previews based on configurable academic and attendance thresholds.
  * Added confirmation and history tracking for promotion, retention, graduation, and leaving-school decisions.
  * Added management of promotion-threshold configurations.
  * Added role-based access controls for previewing, confirming, and viewing promotion decisions.

* **Documentation**
  * Updated API documentation with promotion endpoints, authorization rules, and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->