### PR TITLE
Fix AdmissionIntegrationTest hidden dependency on manually-seeded adm…

### DIFF
--- a/backend/src/test/java/com/schoolmanagement/controller/AdmissionIntegrationTest.java
+++ b/backend/src/test/java/com/schoolmanagement/controller/AdmissionIntegrationTest.java
@@ -286,8 +286,16 @@ class AdmissionIntegrationTest {
     @Test
     @WithMockUser(roles = "ADMIN")
     void approveAndCreate_duplicateUsername_returns409() throws Exception {
+        // Own dedicated User, not a hardcoded seeded username ("admin") - this
+        // test previously assumed TEST_DATA_CORRECTED.sql had already been run
+        // against the DB, which broke on a schema-only fresh install (e.g. via
+        // create_database_from_scratch.sql) where no such seed data exists.
+        userRepository.save(User.builder()
+                .username("itest.existing.username").email("itest.existing.username@school.com")
+                .password("{noop}Str0ngPassw0rd!")
+                .firstName("Existing").lastName("User").role(Role.ADMIN).enabled(true).build());
         AdmissionApplication application = admissionApplicationRepository.save(approvedApplication("ITEST DupUser"));
-        ApproveAndCreateRequest request = approveRequest("admin"); // seeded username, already exists
+        ApproveAndCreateRequest request = approveRequest("itest.existing.username");
 
         mockMvc.perform(post("/v1/admissions/{id}/approve-and-create", application.getId())
                         .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
…in user

Found while verifying the laptop reinstall end-to-end: ran backend/database/create_database_from_scratch.sql (schema only, no data, by design) against a brand-new MySQL install, then `mvn test` - approveAndCreate_duplicateUsername_returns409 failed (expected 409, got 201) because it hardcoded username "admin" assuming that row already existed. It only ever passed because the old dev machine's local DB happened to have an admin user seeded in it at some point (e.g. via TEST_DATA_CORRECTED.sql) - nothing about that dependency was visible from the test itself, and no migration or the bootstrap script creates it.

Fixed by having the test create its own dedicated User first and reuse that username in the approve-and-create request, same pattern already used elsewhere in this file (e.g. updateStatus_setsReviewerAndNote) - the test is now self-contained and passes on a schema-only database with zero seed data.

Verified: mvn -q test on the freshly reinstalled machine, against a DB built solely from create_database_from_scratch.sql (no TEST_DATA_CORRECTED.sql run) - 121/121 tests pass. Confirmed zero stray rows left in admission_applications/students/users afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved duplicate-username integration test reliability by creating its own existing administrator account during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->