### PR TITLE
Phase 3.9: Ha tang dung chung (document attachments, audit log, forgo…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,5 +34,16 @@ MAIL_FROM=no-reply@school.local
 ADMISSION_RATE_LIMIT_MAX=5
 ADMISSION_RATE_LIMIT_WINDOW_MINUTES=60
 # Only set true behind a reverse proxy that sets/overwrites X-Forwarded-For
-# itself — otherwise callers can spoof it to dodge the rate limit.
+# itself — otherwise callers can spoof it to dodge the rate limit. Shared with
+# FORGOT_PASSWORD_RATE_LIMIT_* below (same reasoning, same deployment).
 ADMISSION_TRUST_FORWARDED_FOR=false
+
+# Hạ tầng dùng chung (3.9)
+# Anti-spam rate limit on the public POST /v1/auth/forgot-password endpoint.
+FORGOT_PASSWORD_RATE_LIMIT_MAX=3
+FORGOT_PASSWORD_RATE_LIMIT_WINDOW_MINUTES=60
+# Real frontend route the reset-password email link points at (reads ?token=,
+# calls POST /v1/auth/reset-password).
+FRONTEND_RESET_PASSWORD_URL=http://localhost:3000/reset-password
+# Local filesystem directory for uploaded document attachments.
+UPLOAD_DIR=./uploads

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -144,3 +144,7 @@ ENV/
 *~.nib
 local.properties
 
+# Local document-attachment storage (3.9) — real uploaded files, never
+# committed. See app.uploads.dir / UPLOAD_DIR.
+/uploads/
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -54,6 +54,9 @@ http://localhost:8080/api/swagger-ui.html
 | Fees | `/v1/fees/*` | Student fees & payments |
 | Library | `/v1/library/*` | Book catalog & borrowing |
 | Dashboard | `/v1/dashboard/stats` | Admin summary stats |
+| Documents (Tệp đính kèm) | `/v1/documents/*` | Upload/download/delete file attachments for a STUDENT/STAFF/ADMISSION_APPLICATION owner. Local filesystem storage (see `FileStorageService`), max 10MB, pdf/jpg/jpeg/png/doc/docx/xls/xlsx only. STUDENT/PARENT limited to their own/child's documents; STAFF/ADMISSION_APPLICATION owners are ADMIN/PRINCIPAL-only; deleting is ADMIN/PRINCIPAL-only regardless of owner |
+| Audit Log | `/v1/audit-logs` | ADMIN-only, paginated (`?page=&size=`, default 0/20), optional `?entityType=`/`?actorId=` filters. Written manually at specific sensitive call sites (sửa/xóa điểm, xóa học sinh, duyệt tuyển sinh, cấp tài khoản kèm quyền, đặt lại mật khẩu) — not a blanket interceptor around every create/update/delete in the app |
+| Forgot/Reset Password | `/v1/auth/forgot-password`, `/v1/auth/reset-password` | Both public, no login. `forgot-password` always returns the same generic response regardless of whether the email matches an account (no user enumeration) and is rate-limited per IP (see `ForgotPasswordRateLimitFilter`). Tokens are single-use, expire after 15 minutes, and only their SHA-256 hash is ever persisted |
 
 See [Swagger UI](http://localhost:8080/api/swagger-ui.html) for the full, current contract (request/response shapes, required fields) — the table above is just an index.
 
@@ -68,6 +71,7 @@ See [Swagger UI](http://localhost:8080/api/swagger-ui.html) for the full, curren
 - `V7__promotion_records.sql` added `promotion_threshold_configs` (no default rows — an ADMIN/PRINCIPAL must configure cutoffs via `POST /v1/promotion-thresholds` before any suggestion can be computed) and `promotion_records` (one row per student per academic year, unique constraint enforced). No backfill.
 - `V8__parents_notifications.sql` added `parent_student_relations` (unique per parent+student), `notifications`, `notification_recipients`. No backfill — nothing pre-3.6 represented this data.
 - `V9__admission_applications.sql` added `admission_applications` (optimistic-locked via `@Version` — see the Security note on approve-and-create below). No backfill — nothing pre-3.7 represented this data.
+- `V10__shared_infra.sql` added `document_attachments`, `audit_logs`, `password_reset_tokens`. No backfill — nothing pre-3.9 represented any of this data.
 - Create the database once:
   ```sql
   CREATE DATABASE school_management CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
@@ -95,7 +99,10 @@ Nothing is hard-coded — everything sensitive comes from environment variables 
 | `MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_SMTP_AUTH`, `MAIL_SMTP_STARTTLS` | no | EMAIL notification channel (3.6) — all have defaults; without a real SMTP server, sending just fails per-recipient (recorded, not a crash) |
 | `MAIL_FROM` | no | default `no-reply@school.local` — the "From" address on outgoing EMAIL notifications |
 | `ADMISSION_RATE_LIMIT_MAX`, `ADMISSION_RATE_LIMIT_WINDOW_MINUTES` | no | anti-spam limit on public `POST /v1/admissions` (3.7) — default 5 requests / 60 minutes per IP |
-| `ADMISSION_TRUST_FORWARDED_FOR` | no | default `false` (rate-limits by the real TCP peer address) — only set `true` behind a reverse proxy that sets/overwrites `X-Forwarded-For` itself, otherwise a caller can spoof it to dodge the limit |
+| `ADMISSION_TRUST_FORWARDED_FOR` | no | default `false` (rate-limits by the real TCP peer address) — only set `true` behind a reverse proxy that sets/overwrites `X-Forwarded-For` itself, otherwise a caller can spoof it to dodge the limit. Shared with the forgot-password limiter below |
+| `FORGOT_PASSWORD_RATE_LIMIT_MAX`, `FORGOT_PASSWORD_RATE_LIMIT_WINDOW_MINUTES` | no | anti-spam limit on public `POST /v1/auth/forgot-password` (3.9) — default 3 requests / 60 minutes per IP |
+| `FRONTEND_RESET_PASSWORD_URL` | no | default `http://localhost:3000/reset-password` — the frontend route the reset-password email link points at (reads `?token=`) |
+| `UPLOAD_DIR` | no | default `./uploads` — local filesystem directory for document attachments (3.9) |
 
 ## 🛡️ Security
 
@@ -208,7 +215,9 @@ backend/
 
 ## 🚀 Future enhancements
 
-See the "Giai đoạn 3" section of [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) for the full roadmap — hạ tầng dùng chung (document attachments, audit log, forgot-password). (3.1 Năm học/Học kỳ/Môn học, 3.2 Phân công giảng dạy & Thời khoá biểu, 3.3 Điểm theo TT22, 3.4 Hạnh kiểm/Rèn luyện, 3.5 Xét lên lớp/Ở lại/Tốt nghiệp, 3.6 Phụ huynh & Sổ liên lạc điện tử, 3.7 Tuyển sinh đầu cấp, and 3.8 Xuất báo cáo PDF/Excel are done, above.)
+"Giai đoạn 3" of [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) is now fully implemented (3.1 Năm học/Học kỳ/Môn học through 3.9 Hạ tầng dùng chung — document attachments, audit log, forgot/reset password, above). See the plan for Track Frontend and any further phases.
+
+**Note on 3.9**: `AuditLogService.log(...)` is called manually from a specific, deliberately small set of sensitive operations (grade record update/delete, student delete, admission status-change/approve-and-create, ADMIN-created-account role grants, password reset) rather than via a blanket AOP interceptor around every service's create/update/delete — see its Javadoc for the full list and the reasoning. `DocumentAttachment` files live on local disk (`app.uploads.dir`/`UPLOAD_DIR`), not MinIO/S3 — same "single self-hosted instance" reasoning as the in-memory admission rate limiter (3.7); every stored filename is a server-generated UUID, never derived from the client-supplied original filename, to rule out path traversal. Forgot/reset-password tokens are 256 bits of `SecureRandom`, only their SHA-256 hash is ever persisted, and requesting a new one invalidates any still-outstanding earlier token for that user.
 
 **Note on 3.8**: the transcript PDF shows raw điểm trung bình (per the same formulas as `/v1/grade-records`) and hạnh kiểm per semester — it never shows xếp loại học lực, since that classification still isn't implemented (see the 3.3 note below). Its "Lớp" line is labelled "Lớp (hiện tại)" deliberately — `Student` has no per-academic-year class history, only the student's *current* class, so a transcript pulled for a past year can't show which class they were actually in back then. The class attendance Excel has one column per calendar day in the requested range — fine for a week/month; `[from, to]` is capped at 366 days (one academic year) and returns 400 past that, both to keep the sheet from exceeding Excel's column limit and because that's already far past any realistic use of this report. `GET /fees/receipt/{feeId}` rejects (400) a fee with no `paidAmount` recorded yet — a receipt only makes sense as proof of an actual payment. Every `/v1/reports/*` endpoint's role list deliberately matches the equivalent existing endpoint for the same data (e.g. the transcript matches `/v1/grade-records/student/{id}/year-summary`'s ADMIN/TEACHER/STUDENT/PARENT, not PRINCIPAL) — a report is a different shape of the same data, not a different access policy, so it doesn't unilaterally decide PRINCIPAL should see more than the underlying API already allows.
 

--- a/backend/src/main/java/com/schoolmanagement/config/SecurityConfig.java
+++ b/backend/src/main/java/com/schoolmanagement/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.schoolmanagement.config;
 
 import com.schoolmanagement.security.AdmissionRateLimitFilter;
+import com.schoolmanagement.security.ForgotPasswordRateLimitFilter;
 import com.schoolmanagement.security.JwtAuthenticationFilter;
 import com.schoolmanagement.security.JwtTokenProvider;
 import lombok.AllArgsConstructor;
@@ -35,6 +36,7 @@ public class SecurityConfig {
     private UserDetailsService userDetailsService;
     private JwtTokenProvider jwtTokenProvider;
     private AdmissionRateLimitFilter admissionRateLimitFilter;
+    private ForgotPasswordRateLimitFilter forgotPasswordRateLimitFilter;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -108,7 +110,8 @@ public class SecurityConfig {
             )
             .authenticationProvider(authenticationProvider())
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(admissionRateLimitFilter, JwtAuthenticationFilter.class);
+            .addFilterBefore(admissionRateLimitFilter, JwtAuthenticationFilter.class)
+            .addFilterBefore(forgotPasswordRateLimitFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/backend/src/main/java/com/schoolmanagement/controller/AdmissionController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/AdmissionController.java
@@ -67,7 +67,8 @@ public class AdmissionController {
     @Operation(summary = "Create a User+Student account from an APPROVED application",
             description = "Fails if the application isn't APPROVED yet, or if an account was already created from it.")
     public ResponseEntity<AdmissionApprovalResultDTO> approveAndCreate(
-            @PathVariable Long id, @Valid @RequestBody ApproveAndCreateRequest request) {
-        return new ResponseEntity<>(admissionService.approveAndCreate(id, request), HttpStatus.CREATED);
+            @PathVariable Long id, @Valid @RequestBody ApproveAndCreateRequest request, Authentication authentication) {
+        User actor = (User) authentication.getPrincipal();
+        return new ResponseEntity<>(admissionService.approveAndCreate(id, request, actor), HttpStatus.CREATED);
     }
 }

--- a/backend/src/main/java/com/schoolmanagement/controller/AuditLogController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/AuditLogController.java
@@ -1,0 +1,53 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.dto.AuditLogDTO;
+import com.schoolmanagement.service.AuditLogService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * ADMIN-only read access to the audit trail (IMPLEMENTATION_PLAN.md 3.9).
+ * Always paginated — unlike most other list endpoints in this app, there is
+ * no unpaginated caller to stay backward-compatible with (this is a brand
+ * new endpoint) and an audit table only ever grows, so an unbounded
+ * "return everything" default isn't offered here.
+ */
+@RestController
+@RequestMapping("/v1/audit-logs")
+@AllArgsConstructor
+@Tag(name = "Audit Log", description = "Nhật ký các thao tác nhạy cảm (sửa/xóa điểm, xóa học sinh, duyệt tuyển sinh, cấp quyền, đặt lại mật khẩu).")
+public class AuditLogController {
+
+    private AuditLogService auditLogService;
+
+    @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "List audit log entries, newest first",
+            description = "Optional ?entityType= and ?actorId= filters. page/size default to 0/20.")
+    public ResponseEntity<Page<AuditLogDTO>> search(
+            @RequestParam(required = false) String entityType,
+            @RequestParam(required = false) Long actorId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        if (page < 0) {
+            throw new IllegalArgumentException("page must not be negative");
+        }
+        if (size <= 0 || size > 200) {
+            throw new IllegalArgumentException("size must be between 1 and 200");
+        }
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "occurredAt"));
+        return new ResponseEntity<>(auditLogService.search(entityType, actorId, pageable), HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/controller/AuthController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/AuthController.java
@@ -2,8 +2,11 @@ package com.schoolmanagement.controller;
 
 import com.schoolmanagement.dto.AuthRequest;
 import com.schoolmanagement.dto.AuthResponse;
+import com.schoolmanagement.dto.ForgotPasswordRequest;
 import com.schoolmanagement.dto.RegisterRequest;
+import com.schoolmanagement.dto.ResetPasswordRequest;
 import com.schoolmanagement.service.AuthenticationService;
+import com.schoolmanagement.service.PasswordResetService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -12,6 +15,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/v1/auth")
 @AllArgsConstructor
@@ -19,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private AuthenticationService authenticationService;
+    private PasswordResetService passwordResetService;
 
     @PostMapping("/register")
     @Operation(summary = "Register a new user (always created as STUDENT — an ADMIN must use POST /v1/users to grant any other role)")
@@ -40,6 +46,26 @@ public class AuthController {
         String token = refreshToken.replace("Bearer ", "");
         AuthResponse response = authenticationService.refreshToken(token);
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @PostMapping("/forgot-password")
+    @Operation(summary = "Request a password reset email",
+            description = "Public — no login required, rate-limited per IP (see ForgotPasswordRateLimitFilter). "
+                    + "Always returns the same generic response whether or not the email matches an account, "
+                    + "so this can't be used to enumerate registered emails.")
+    public ResponseEntity<Map<String, String>> forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
+        passwordResetService.forgotPassword(request.getEmail());
+        return new ResponseEntity<>(
+                Map.of("message", "Nếu email này đã đăng ký, một liên kết đặt lại mật khẩu đã được gửi tới đó."),
+                HttpStatus.OK);
+    }
+
+    @PostMapping("/reset-password")
+    @Operation(summary = "Reset a password using a forgot-password token",
+            description = "Public — no login required. The token is single-use and expires 15 minutes after being issued.")
+    public ResponseEntity<Map<String, String>> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+        passwordResetService.resetPassword(request.getToken(), request.getNewPassword());
+        return new ResponseEntity<>(Map.of("message", "Mật khẩu đã được đặt lại thành công."), HttpStatus.OK);
     }
 }
 

--- a/backend/src/main/java/com/schoolmanagement/controller/DocumentController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/DocumentController.java
@@ -1,0 +1,99 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.dto.DocumentAttachmentDTO;
+import com.schoolmanagement.entity.DocumentAttachment;
+import com.schoolmanagement.entity.DocumentOwnerType;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.service.DocumentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * File attachments (hồ sơ học sinh, hồ sơ nhân sự, giấy tờ tuyển sinh), per
+ * IMPLEMENTATION_PLAN.md 3.9. Object-level access (a STUDENT/PARENT only
+ * reaching their own/child's documents; STAFF/ADMISSION_APPLICATION
+ * restricted to ADMIN/PRINCIPAL) is enforced inside {@link DocumentService} —
+ * see its Javadoc.
+ */
+@RestController
+@RequestMapping("/v1/documents")
+@AllArgsConstructor
+@Tag(name = "Documents (Tệp đính kèm)", description = "Upload/download/xóa file đính kèm cho học sinh, nhân sự, hồ sơ tuyển sinh.")
+public class DocumentController {
+
+    private DocumentService documentService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasAnyRole('ADMIN','PRINCIPAL','TEACHER','STUDENT','PARENT')")
+    @Operation(summary = "Upload a document attachment",
+            description = "Max 10MB; accepted types: pdf, jpg, jpeg, png, doc, docx, xls, xlsx.")
+    public ResponseEntity<DocumentAttachmentDTO> upload(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam DocumentOwnerType ownerType,
+            @RequestParam Long ownerId,
+            Authentication authentication) {
+        User requester = (User) authentication.getPrincipal();
+        return new ResponseEntity<>(documentService.upload(file, ownerType, ownerId, requester), HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN','PRINCIPAL','TEACHER','STUDENT','PARENT')")
+    @Operation(summary = "List documents for one owner")
+    public ResponseEntity<List<DocumentAttachmentDTO>> listByOwner(
+            @RequestParam DocumentOwnerType ownerType, @RequestParam Long ownerId, Authentication authentication) {
+        User requester = (User) authentication.getPrincipal();
+        return new ResponseEntity<>(documentService.listByOwner(ownerType, ownerId, requester), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN','PRINCIPAL','TEACHER','STUDENT','PARENT')")
+    @Operation(summary = "Get one document's metadata")
+    public ResponseEntity<DocumentAttachmentDTO> getById(@PathVariable Long id, Authentication authentication) {
+        User requester = (User) authentication.getPrincipal();
+        return new ResponseEntity<>(documentService.getById(id, requester), HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}/download")
+    @PreAuthorize("hasAnyRole('ADMIN','PRINCIPAL','TEACHER','STUDENT','PARENT')")
+    @Operation(summary = "Download a document's bytes")
+    public ResponseEntity<Resource> download(@PathVariable Long id, Authentication authentication) {
+        User requester = (User) authentication.getPrincipal();
+        DocumentAttachment attachment = documentService.loadForDownload(id, requester);
+        Resource resource = documentService.loadFileResource(attachment.getStoredFileName());
+
+        HttpHeaders headers = new HttpHeaders();
+        // filename(name, charset), not the single-arg overload: a Vietnamese
+        // original filename (very plausible on this system - "Học_bạ.pdf" etc.)
+        // needs RFC 5987 percent-encoding, which only the 2-arg form applies;
+        // the 1-arg form quotes the raw UTF-8 bytes verbatim, which strict
+        // HTTP clients can reject or garble.
+        headers.setContentDisposition(ContentDisposition.attachment()
+                .filename(attachment.getFileName(), java.nio.charset.StandardCharsets.UTF_8).build());
+        return ResponseEntity.ok()
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(resource);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyRole('ADMIN','PRINCIPAL')")
+    @Operation(summary = "Delete a document attachment (metadata + the stored file)")
+    public ResponseEntity<Void> delete(@PathVariable Long id, Authentication authentication) {
+        User requester = (User) authentication.getPrincipal();
+        documentService.delete(id, requester);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/controller/GradeRecordController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/GradeRecordController.java
@@ -36,8 +36,10 @@ public class GradeRecordController {
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN') or hasRole('TEACHER')")
     @Operation(summary = "Update a grade record")
-    public ResponseEntity<GradeRecordDTO> updateGradeRecord(@PathVariable Long id, @Valid @RequestBody GradeRecord request) {
-        return new ResponseEntity<>(gradeRecordService.updateGradeRecord(id, request), HttpStatus.OK);
+    public ResponseEntity<GradeRecordDTO> updateGradeRecord(
+            @PathVariable Long id, @Valid @RequestBody GradeRecord request, Authentication authentication) {
+        User actor = (User) authentication.getPrincipal();
+        return new ResponseEntity<>(gradeRecordService.updateGradeRecord(id, request, actor), HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
@@ -52,8 +54,9 @@ public class GradeRecordController {
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN') or hasRole('TEACHER')")
     @Operation(summary = "Delete a grade record")
-    public ResponseEntity<Void> deleteGradeRecord(@PathVariable Long id) {
-        gradeRecordService.deleteGradeRecord(id);
+    public ResponseEntity<Void> deleteGradeRecord(@PathVariable Long id, Authentication authentication) {
+        User actor = (User) authentication.getPrincipal();
+        gradeRecordService.deleteGradeRecord(id, actor);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/backend/src/main/java/com/schoolmanagement/controller/StudentController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/StudentController.java
@@ -2,6 +2,7 @@ package com.schoolmanagement.controller;
 
 import com.schoolmanagement.dto.StudentDTO;
 import com.schoolmanagement.entity.Student;
+import com.schoolmanagement.entity.User;
 import com.schoolmanagement.service.StudentService;
 import com.schoolmanagement.util.PaginationUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -103,8 +105,9 @@ public class StudentController {
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN') or hasRole('PRINCIPAL')")
     @Operation(summary = "Delete student")
-    public ResponseEntity<Void> deleteStudent(@PathVariable Long id) {
-        studentService.deleteStudent(id);
+    public ResponseEntity<Void> deleteStudent(@PathVariable Long id, Authentication authentication) {
+        User actor = (User) authentication.getPrincipal();
+        studentService.deleteStudent(id, actor);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/backend/src/main/java/com/schoolmanagement/controller/UserController.java
+++ b/backend/src/main/java/com/schoolmanagement/controller/UserController.java
@@ -2,6 +2,7 @@ package com.schoolmanagement.controller;
 
 import com.schoolmanagement.dto.AuthResponse;
 import com.schoolmanagement.dto.CreateUserRequest;
+import com.schoolmanagement.entity.User;
 import com.schoolmanagement.service.AuthenticationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -10,6 +11,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,8 +25,9 @@ public class UserController {
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "Create a user account with an explicit role (ADMIN only)")
-    public ResponseEntity<AuthResponse> createUser(@Valid @RequestBody CreateUserRequest request) {
-        AuthResponse response = authenticationService.createUserByAdmin(request);
+    public ResponseEntity<AuthResponse> createUser(@Valid @RequestBody CreateUserRequest request, Authentication authentication) {
+        User actor = (User) authentication.getPrincipal();
+        AuthResponse response = authenticationService.createUserByAdmin(request, actor);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 }

--- a/backend/src/main/java/com/schoolmanagement/dto/AuditLogDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/AuditLogDTO.java
@@ -1,0 +1,30 @@
+package com.schoolmanagement.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Schema(description = "One recorded sensitive operation.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuditLogDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private Long actorId;
+    private String actorName;
+    private String action;
+    private String entityType;
+    private Long entityId;
+    private LocalDateTime occurredAt;
+
+    @Schema(description = "Free-form JSON context (e.g. old/new values) - null if none was recorded for this event.")
+    private String detailJson;
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/DocumentAttachmentDTO.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/DocumentAttachmentDTO.java
@@ -1,0 +1,33 @@
+package com.schoolmanagement.dto;
+
+import com.schoolmanagement.entity.DocumentOwnerType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Schema(description = "Metadata for one uploaded file. The actual bytes are fetched separately via downloadUrl.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DocumentAttachmentDTO implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private DocumentOwnerType ownerType;
+    private Long ownerId;
+    private String fileName;
+    private String fileType;
+    private Long fileSize;
+    private Long uploadedById;
+    private String uploadedByName;
+    private LocalDateTime uploadedAt;
+
+    @Schema(description = "GET this URL (with auth) to download the file bytes.")
+    private String downloadUrl;
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/ForgotPasswordRequest.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/ForgotPasswordRequest.java
@@ -1,0 +1,25 @@
+package com.schoolmanagement.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Schema(description = "Public — no login required. Always responds the same way regardless of whether the email matches an account, to avoid leaking which emails are registered.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ForgotPasswordRequest implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Schema(example = "student1@school.com")
+    @NotBlank
+    @Email
+    private String email;
+}

--- a/backend/src/main/java/com/schoolmanagement/dto/ResetPasswordRequest.java
+++ b/backend/src/main/java/com/schoolmanagement/dto/ResetPasswordRequest.java
@@ -1,0 +1,28 @@
+package com.schoolmanagement.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Schema(description = "Public — the token from the reset-password email link.")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ResetPasswordRequest implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @NotBlank
+    private String token;
+
+    @Schema(example = "N3wStr0ngPassw0rd!", minLength = 8)
+    @NotBlank
+    @Size(min = 8)
+    private String newPassword;
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/AuditLog.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/AuditLog.java
@@ -1,0 +1,55 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * One record of a sensitive operation, per IMPLEMENTATION_PLAN.md 3.9 —
+ * written manually (via AuditLogService.log) at the specific call sites that
+ * actually need a trail (sửa/xóa điểm, xóa học sinh, duyệt tuyển sinh, cấp
+ * quyền, đặt lại mật khẩu), not via a blanket AOP interceptor around every
+ * create/update/delete in the app. See AuditLogService's Javadoc for the
+ * full list of instrumented call sites and the reasoning for this scope.
+ */
+@Entity
+@Table(name = "audit_logs")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_id", nullable = false)
+    private User actor;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String action;
+
+    @NotBlank
+    @Column(name = "entity_type", nullable = false)
+    private String entityType;
+
+    @Column(name = "entity_id")
+    private Long entityId;
+
+    @Column(name = "occurred_at", nullable = false)
+    @Builder.Default
+    private LocalDateTime occurredAt = LocalDateTime.now();
+
+    @Column(name = "detail_json", columnDefinition = "TEXT")
+    private String detailJson;
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/DocumentAttachment.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/DocumentAttachment.java
@@ -1,0 +1,71 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * A file uploaded against some other entity (student hồ sơ, staff document,
+ * admission application attachment...) — per IMPLEMENTATION_PLAN.md 3.9.
+ * ownerType+ownerId is the same polymorphic-owner pattern Notification
+ * already uses (targetType+targetId).
+ *
+ * <p>The file itself lives on local disk (see FileStorageService /
+ * app.uploads.dir), named by {@link #storedFileName} — a generated,
+ * collision-proof, path-traversal-proof name, deliberately never derived
+ * from the client-supplied {@link #fileName}. fileName is metadata only
+ * (what to show the user, what to name the file on download) and is never
+ * used to build a filesystem path.
+ */
+@Entity
+@Table(name = "document_attachments")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DocumentAttachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "owner_type", nullable = false)
+    private DocumentOwnerType ownerType;
+
+    @NotNull
+    @Column(name = "owner_id", nullable = false)
+    private Long ownerId;
+
+    @NotBlank
+    @Column(name = "file_name", nullable = false)
+    private String fileName;
+
+    @NotBlank
+    @Column(name = "stored_file_name", nullable = false, unique = true)
+    private String storedFileName;
+
+    @NotBlank
+    @Column(name = "file_type", nullable = false)
+    private String fileType;
+
+    @NotNull
+    @Column(name = "file_size", nullable = false)
+    private Long fileSize;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uploaded_by_id", nullable = false)
+    private User uploadedBy;
+
+    @Column(name = "uploaded_at", nullable = false)
+    @Builder.Default
+    private LocalDateTime uploadedAt = LocalDateTime.now();
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/DocumentOwnerType.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/DocumentOwnerType.java
@@ -1,0 +1,11 @@
+package com.schoolmanagement.entity;
+
+/**
+ * What a DocumentAttachment's ownerId refers to, per IMPLEMENTATION_PLAN.md
+ * 3.9 — same polymorphic-owner pattern as NotificationTargetType.
+ */
+public enum DocumentOwnerType {
+    STUDENT,
+    STAFF,
+    ADMISSION_APPLICATION
+}

--- a/backend/src/main/java/com/schoolmanagement/entity/PasswordResetToken.java
+++ b/backend/src/main/java/com/schoolmanagement/entity/PasswordResetToken.java
@@ -1,0 +1,53 @@
+package com.schoolmanagement.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * A forgot-password reset token, per IMPLEMENTATION_PLAN.md 3.9. Only
+ * {@link #tokenHash} (SHA-256 of the raw token) is ever persisted — the raw
+ * token exists only in the outgoing email link and the incoming reset
+ * request, never in the database, so a DB leak alone can't be used to reset
+ * anyone's password. Expires 15 minutes after creation ({@link #expiresAt});
+ * {@link #usedAt} is set the moment it's redeemed so a captured-but-already-
+ * used link can't be replayed.
+ */
+@Entity
+@Table(name = "password_reset_tokens")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PasswordResetToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @NotBlank
+    @Column(name = "token_hash", nullable = false, unique = true)
+    private String tokenHash;
+
+    @NotNull
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Builder.Default
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/AuditLogRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/AuditLogRepository.java
@@ -1,0 +1,23 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.AuditLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+
+    // JOIN FETCH actor to avoid one lazy-load query per row across a page of
+    // results; :entityType/:actorId are optional (null = don't filter on it).
+    // Sorting comes from the caller's Pageable (see AuditLogController), not
+    // a static ORDER BY here - mixing both risks Spring Data emitting two
+    // conflicting ORDER BY clauses.
+    @Query("SELECT a FROM AuditLog a LEFT JOIN FETCH a.actor "
+            + "WHERE (:entityType IS NULL OR a.entityType = :entityType) "
+            + "AND (:actorId IS NULL OR a.actor.id = :actorId)")
+    Page<AuditLog> search(@Param("entityType") String entityType, @Param("actorId") Long actorId, Pageable pageable);
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/DocumentAttachmentRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/DocumentAttachmentRepository.java
@@ -1,0 +1,25 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.DocumentAttachment;
+import com.schoolmanagement.entity.DocumentOwnerType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DocumentAttachmentRepository extends JpaRepository<DocumentAttachment, Long> {
+
+    // JOIN FETCH uploadedBy to avoid one lazy-load query per row when listing
+    // a whole owner's documents (mapToDTO reads uploadedBy for uploadedByName).
+    @Query("SELECT d FROM DocumentAttachment d LEFT JOIN FETCH d.uploadedBy "
+            + "WHERE d.ownerType = :ownerType AND d.ownerId = :ownerId ORDER BY d.uploadedAt DESC")
+    List<DocumentAttachment> findByOwnerTypeAndOwnerIdOrderByUploadedAtDesc(
+            @Param("ownerType") DocumentOwnerType ownerType, @Param("ownerId") Long ownerId);
+
+    @Query("SELECT d FROM DocumentAttachment d LEFT JOIN FETCH d.uploadedBy WHERE d.id = :id")
+    Optional<DocumentAttachment> findByIdWithUploadedBy(@Param("id") Long id);
+}

--- a/backend/src/main/java/com/schoolmanagement/repository/PasswordResetTokenRepository.java
+++ b/backend/src/main/java/com/schoolmanagement/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,19 @@
+package com.schoolmanagement.repository;
+
+import com.schoolmanagement.entity.PasswordResetToken;
+import com.schoolmanagement.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+    Optional<PasswordResetToken> findByTokenHash(String tokenHash);
+
+    // To invalidate every outstanding token for a user the moment they
+    // request a new one, or successfully reset their password - an old,
+    // still-unexpired link must stop working once a newer one exists.
+    List<PasswordResetToken> findByUserAndUsedAtIsNull(User user);
+}

--- a/backend/src/main/java/com/schoolmanagement/security/ForgotPasswordRateLimitFilter.java
+++ b/backend/src/main/java/com/schoolmanagement/security/ForgotPasswordRateLimitFilter.java
@@ -1,0 +1,99 @@
+package com.schoolmanagement.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Anti-spam rate limit for the public POST /v1/auth/forgot-password endpoint
+ * — per IMPLEMENTATION_PLAN.md 3.9. Without this, the endpoint is a free
+ * email bomb against any registered address (every call sends one email) and
+ * a way to churn through SMTP quota. Same {@link SlidingWindowRateLimiter}
+ * mechanism {@link AdmissionRateLimitFilter} uses, tuned tighter by default
+ * (this endpoint has no legitimate reason to be called more than a couple
+ * times an hour by the same caller).
+ */
+@Component
+public class ForgotPasswordRateLimitFilter extends OncePerRequestFilter {
+
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    /** Same reasoning as AdmissionRateLimitFilter.trustForwardedFor - see its Javadoc. */
+    private final boolean trustForwardedFor;
+    private final SlidingWindowRateLimiter limiter;
+
+    // Built eagerly here, not lazily on first request: a lazy `if (limiter ==
+    // null) limiter = new ...` is not thread-safe - concurrent requests could
+    // each see null and build their own separate limiter with an empty
+    // counter, multiplying the effective rate limit by however many threads
+    // raced (defeating the anti-spam/email-enumeration protection this filter
+    // exists for). @Value works on a constructor parameter (unlike a
+    // Lombok-generated all-args constructor's parameters, which don't carry
+    // field annotations - see PasswordResetService's Javadoc for the same gotcha).
+    public ForgotPasswordRateLimitFilter(
+            @Value("${app.auth.forgot-password-rate-limit.max-requests:3}") int maxRequests,
+            @Value("${app.auth.forgot-password-rate-limit.window-minutes:60}") int windowMinutes,
+            @Value("${app.auth.forgot-password-rate-limit.trust-forwarded-for:false}") boolean trustForwardedFor) {
+        this.trustForwardedFor = trustForwardedFor;
+        this.limiter = new SlidingWindowRateLimiter(maxRequests, Duration.ofMinutes(windowMinutes));
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (!isForgotPasswordRequest(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String clientIp = resolveClientIp(request);
+        if (!limiter.tryConsume(clientIp)) {
+            respondTooManyRequests(response, request);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    @Scheduled(fixedRateString = "${app.auth.forgot-password-rate-limit.window-minutes:60}", timeUnit = TimeUnit.MINUTES)
+    void evictStaleEntries() {
+        limiter.evictStale();
+    }
+
+    private boolean isForgotPasswordRequest(HttpServletRequest request) {
+        return "POST".equalsIgnoreCase(request.getMethod()) && request.getRequestURI().endsWith("/v1/auth/forgot-password");
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        if (trustForwardedFor) {
+            String forwarded = request.getHeader("X-Forwarded-For");
+            if (forwarded != null && !forwarded.isBlank()) {
+                return forwarded.split(",")[0].trim();
+            }
+        }
+        return request.getRemoteAddr();
+    }
+
+    private void respondTooManyRequests(HttpServletResponse response, HttpServletRequest request) throws IOException {
+        response.setStatus(429);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{"
+                + "\"status\":\"TOO_MANY_REQUESTS\","
+                + "\"message\":\"Bạn đã yêu cầu đặt lại mật khẩu quá nhiều lần, vui lòng thử lại sau.\","
+                + "\"code\":429,"
+                + "\"path\":\"" + request.getRequestURI() + "\","
+                + "\"timestamp\":\"" + TIMESTAMP_FORMAT.format(LocalDateTime.now()) + "\""
+                + "}");
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/security/SlidingWindowRateLimiter.java
+++ b/backend/src/main/java/com/schoolmanagement/security/SlidingWindowRateLimiter.java
@@ -1,0 +1,97 @@
+package com.schoolmanagement.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A simple in-memory per-key sliding-window rate limiter — no Redis/
+ * distributed store, matching this project's single-instance, self-hosted
+ * deployment model (would need a shared store if this app is ever scaled to
+ * multiple instances behind a load balancer). Extracted from
+ * {@link AdmissionRateLimitFilter} (3.7) when a second consumer
+ * ({@code ForgotPasswordRateLimitFilter}, 3.9) needed the identical logic
+ * with different limits — {@link AdmissionRateLimitFilter} itself is left
+ * on its own already-shipped, already-reviewed inline copy rather than
+ * migrated onto this, to avoid re-risking stable code for reuse's own sake.
+ *
+ * <p>Not a Spring bean — each caller owns its own instance (constructed with
+ * its own max-requests/window) and its own {@code @Scheduled} eviction
+ * method, since scheduling only applies to Spring-managed bean methods, not
+ * plain objects.
+ *
+ * <p>Every mutation of the underlying map — recording a new event and
+ * evicting stale entries alike — goes through a {@code compute}-family call
+ * for the same key, never a plain get-then-synchronized-mutate: {@link
+ * ConcurrentHashMap}'s compute-family methods are mutually exclusive per
+ * key, so a concurrent eviction sweep can never remove a key's bucket in the
+ * narrow window between a request reading the map and that same request
+ * recording its own event — which would otherwise silently lose that event
+ * from tracking right at an eviction boundary, quietly loosening the limit.
+ */
+public class SlidingWindowRateLimiter {
+
+    private static final Logger log = LoggerFactory.getLogger(SlidingWindowRateLimiter.class);
+
+    private final int maxEvents;
+    private final Duration window;
+    private final ConcurrentHashMap<String, Deque<Instant>> eventsByKey = new ConcurrentHashMap<>();
+
+    public SlidingWindowRateLimiter(int maxEvents, Duration window) {
+        this.maxEvents = maxEvents;
+        this.window = window;
+    }
+
+    /** @return true if this event is allowed (and is now recorded); false if the key is over its limit. */
+    public boolean tryConsume(String key) {
+        Instant windowStart = Instant.now().minus(window);
+        AtomicBoolean allowed = new AtomicBoolean(true);
+
+        eventsByKey.compute(key, (k, existing) -> {
+            Deque<Instant> events = existing != null ? existing : new ConcurrentLinkedDeque<>();
+            pruneOlderThan(events, windowStart);
+            if (events.size() >= maxEvents) {
+                allowed.set(false);
+            } else {
+                events.addLast(Instant.now());
+            }
+            return events;
+        });
+
+        return allowed.get();
+    }
+
+    /** Sweeps every tracked key's deque so a one-time caller's entry doesn't live in memory forever. */
+    public void evictStale() {
+        Instant windowStart = Instant.now().minus(window);
+        AtomicInteger removed = new AtomicInteger();
+
+        for (String key : eventsByKey.keySet()) {
+            eventsByKey.computeIfPresent(key, (k, events) -> {
+                pruneOlderThan(events, windowStart);
+                if (events.isEmpty()) {
+                    removed.incrementAndGet();
+                    return null; // removes the entry
+                }
+                return events;
+            });
+        }
+
+        if (removed.get() > 0) {
+            log.debug("SlidingWindowRateLimiter: evicted {} stale entries", removed.get());
+        }
+    }
+
+    private void pruneOlderThan(Deque<Instant> events, Instant windowStart) {
+        while (!events.isEmpty() && events.peekFirst().isBefore(windowStart)) {
+            events.pollFirst();
+        }
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/service/AdmissionService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/AdmissionService.java
@@ -42,6 +42,7 @@ public class AdmissionService {
     private UserRepository userRepository;
     private StudentRepository studentRepository;
     private PasswordEncoder passwordEncoder;
+    private AuditLogService auditLogService;
 
     public AdmissionApplicationDTO submit(SubmitAdmissionRequest request) {
         AdmissionApplication application = AdmissionApplication.builder()
@@ -89,7 +90,12 @@ public class AdmissionService {
         }
         application.setReviewedBy(reviewer);
 
-        return mapToDTO(admissionApplicationRepository.save(application));
+        AdmissionApplicationDTO result = mapToDTO(admissionApplicationRepository.save(application));
+
+        auditLogService.log(reviewer, "STATUS_CHANGE", "AdmissionApplication", id,
+                java.util.Map.of("newStatus", request.getStatus().name()));
+
+        return result;
     }
 
     /**
@@ -98,7 +104,7 @@ public class AdmissionService {
      * password/rollNumber/admissionNumber must be supplied (nothing to pull
      * them from — see ApproveAndCreateRequest's Javadoc).
      */
-    public AdmissionApprovalResultDTO approveAndCreate(Long id, ApproveAndCreateRequest request) {
+    public AdmissionApprovalResultDTO approveAndCreate(Long id, ApproveAndCreateRequest request, User actor) {
         AdmissionApplication application = admissionApplicationRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Admission application not found with id: " + id));
 
@@ -180,7 +186,7 @@ public class AdmissionService {
                     "Application " + id + " was just processed by another request — check its current status before retrying");
         }
 
-        return AdmissionApprovalResultDTO.builder()
+        AdmissionApprovalResultDTO result = AdmissionApprovalResultDTO.builder()
                 .applicationId(application.getId())
                 .userId(user.getId())
                 .username(user.getUsername())
@@ -188,6 +194,11 @@ public class AdmissionService {
                 .rollNumber(student.getRollNumber())
                 .admissionNumber(student.getAdmissionNumber())
                 .build();
+
+        auditLogService.log(actor, "APPROVE_AND_CREATE", "AdmissionApplication", id,
+                java.util.Map.of("createdUserId", String.valueOf(user.getId()), "createdStudentId", String.valueOf(student.getId())));
+
+        return result;
     }
 
     /**

--- a/backend/src/main/java/com/schoolmanagement/service/AuditLogService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/AuditLogService.java
@@ -1,0 +1,93 @@
+package com.schoolmanagement.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schoolmanagement.dto.AuditLogDTO;
+import com.schoolmanagement.entity.AuditLog;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.repository.AuditLogRepository;
+import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+/**
+ * Writes one {@link AuditLog} row per sensitive operation, per
+ * IMPLEMENTATION_PLAN.md 3.9. Called manually from the specific service
+ * methods that need a trail, NOT via a blanket AOP interceptor around every
+ * create/update/delete in the app — that would touch 20+ existing services
+ * for one phase, bury genuinely sensitive events under routine ones (e.g.
+ * editing a library book's description), and be much harder to review.
+ *
+ * <p>Currently instrumented call sites:
+ * <ul>
+ *   <li>{@link GradeRecordService#updateGradeRecord} / {@link GradeRecordService#deleteGradeRecord} — sửa/xóa điểm</li>
+ *   <li>{@link StudentService#deleteStudent} — xóa học sinh</li>
+ *   <li>{@link AdmissionService#updateStatus} / {@link AdmissionService#approveAndCreate} — duyệt tuyển sinh</li>
+ *   <li>{@link AuthenticationService#createUserByAdmin} — cấp tài khoản kèm quyền</li>
+ *   <li>{@link PasswordResetService#resetPassword} — đặt lại mật khẩu</li>
+ * </ul>
+ *
+ * <p>Deliberately runs in the SAME transaction as the operation it's
+ * logging (no {@code REQUIRES_NEW}) — if that operation rolls back, the log
+ * entry must roll back with it; a log claiming something happened that
+ * didn't would be worse than no log at all.
+ */
+@Service
+@AllArgsConstructor
+@Transactional
+public class AuditLogService {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditLogService.class);
+
+    private AuditLogRepository auditLogRepository;
+    private ObjectMapper objectMapper;
+
+    /**
+     * @param detail free-form context (e.g. old/new values) - optional, may be null.
+     *               Serialization failures are swallowed (logged, detail stored as
+     *               null) rather than allowed to fail the real operation being audited.
+     */
+    public void log(User actor, String action, String entityType, Long entityId, Map<String, Object> detail) {
+        String detailJson = null;
+        if (detail != null) {
+            try {
+                detailJson = objectMapper.writeValueAsString(detail);
+            } catch (Exception ex) {
+                log.warn("Failed to serialize audit detail for {} {} #{} - logging without it: {}",
+                        action, entityType, entityId, ex.getMessage());
+            }
+        }
+
+        auditLogRepository.save(AuditLog.builder()
+                .actor(actor)
+                .action(action)
+                .entityType(entityType)
+                .entityId(entityId)
+                .detailJson(detailJson)
+                .build());
+    }
+
+    @Transactional(readOnly = true)
+    public Page<AuditLogDTO> search(String entityType, Long actorId, Pageable pageable) {
+        return auditLogRepository.search(entityType, actorId, pageable).map(this::mapToDTO);
+    }
+
+    private AuditLogDTO mapToDTO(AuditLog entry) {
+        User actor = entry.getActor();
+        return AuditLogDTO.builder()
+                .id(entry.getId())
+                .actorId(actor != null ? actor.getId() : null)
+                .actorName(actor != null ? actor.getFirstName() + " " + actor.getLastName() : null)
+                .action(entry.getAction())
+                .entityType(entry.getEntityType())
+                .entityId(entry.getEntityId())
+                .occurredAt(entry.getOccurredAt())
+                .detailJson(entry.getDetailJson())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/service/AuthenticationService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/AuthenticationService.java
@@ -35,11 +35,12 @@ public class AuthenticationService {
     private PasswordEncoder passwordEncoder;
     private AuthenticationManager authenticationManager;
     private JwtTokenProvider jwtTokenProvider;
+    private AuditLogService auditLogService;
 
     /**
      * Self-service registration. Always creates a STUDENT account — RegisterRequest
      * has no `role` field, so a client has no channel to request a privileged role.
-     * ADMIN must use {@link #createUserByAdmin(CreateUserRequest)} to grant other roles.
+     * ADMIN must use {@link #createUserByAdmin(CreateUserRequest, User)} to grant other roles.
      */
     public AuthResponse register(RegisterRequest request) {
         if (userRepository.existsByUsername(request.getUsername())) {
@@ -71,7 +72,7 @@ public class AuthenticationService {
      * ADMIN-only account creation with an explicit role. Only reachable via
      * POST /v1/users, which requires ROLE_ADMIN (see UserController).
      */
-    public AuthResponse createUserByAdmin(CreateUserRequest request) {
+    public AuthResponse createUserByAdmin(CreateUserRequest request, User actor) {
         if (userRepository.existsByUsername(request.getUsername())) {
             throw new DuplicateResourceException("Username already exists");
         }
@@ -93,6 +94,9 @@ public class AuthenticationService {
 
         User savedUser = userRepository.save(user);
         String refreshToken = jwtTokenProvider.generateRefreshToken(savedUser);
+
+        auditLogService.log(actor, "CREATE", "User", savedUser.getId(),
+                java.util.Map.of("username", savedUser.getUsername(), "role", savedUser.getRole().name()));
 
         return buildAuthResponse(savedUser, null, refreshToken);
     }

--- a/backend/src/main/java/com/schoolmanagement/service/DocumentService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/DocumentService.java
@@ -1,0 +1,212 @@
+package com.schoolmanagement.service;
+
+import com.schoolmanagement.dto.DocumentAttachmentDTO;
+import com.schoolmanagement.entity.DocumentAttachment;
+import com.schoolmanagement.entity.DocumentOwnerType;
+import com.schoolmanagement.entity.Role;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.exception.ResourceNotFoundException;
+import com.schoolmanagement.repository.AdmissionApplicationRepository;
+import com.schoolmanagement.repository.DocumentAttachmentRepository;
+import com.schoolmanagement.repository.StaffRepository;
+import com.schoolmanagement.repository.StudentRepository;
+import com.schoolmanagement.security.StudentAccessGuard;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * File attachment metadata + access control, per IMPLEMENTATION_PLAN.md 3.9.
+ * The actual bytes live on local disk (see {@link FileStorageService});
+ * this service owns the {@link DocumentAttachment} rows and who's allowed to
+ * touch them.
+ *
+ * <p>Object-level access: for {@code ownerType == STUDENT}, delegates to
+ * {@link StudentAccessGuard} (same self-access pattern grades/fees/conduct
+ * already use) so a STUDENT/PARENT may only reach their own/child's
+ * documents; ADMIN/PRINCIPAL/TEACHER are unrestricted. STAFF and
+ * ADMISSION_APPLICATION documents are administrative records with no
+ * "self-service" caller — ADMIN/PRINCIPAL only, matching how
+ * {@code /v1/admissions} itself is ADMIN-only. Deleting a document (any
+ * owner type) is ADMIN/PRINCIPAL only.
+ */
+@Service
+@Transactional
+public class DocumentService {
+
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(
+            "pdf", "jpg", "jpeg", "png", "doc", "docx", "xls", "xlsx");
+    private static final long MAX_FILE_SIZE_BYTES = 10L * 1024 * 1024; // 10 MB
+
+    private final DocumentAttachmentRepository documentAttachmentRepository;
+    private final StudentRepository studentRepository;
+    private final StaffRepository staffRepository;
+    private final AdmissionApplicationRepository admissionApplicationRepository;
+    private final StudentAccessGuard studentAccessGuard;
+    private final FileStorageService fileStorageService;
+    private final String contextPath;
+
+    // Not @AllArgsConstructor: needs @Value on contextPath, which a
+    // Lombok-generated constructor's parameter wouldn't carry - see
+    // PasswordResetService's Javadoc for the same gotcha (and the startup
+    // failure it caused before being caught there).
+    public DocumentService(DocumentAttachmentRepository documentAttachmentRepository,
+                            StudentRepository studentRepository,
+                            StaffRepository staffRepository,
+                            AdmissionApplicationRepository admissionApplicationRepository,
+                            StudentAccessGuard studentAccessGuard,
+                            FileStorageService fileStorageService,
+                            @Value("${server.servlet.context-path:}") String contextPath) {
+        this.documentAttachmentRepository = documentAttachmentRepository;
+        this.studentRepository = studentRepository;
+        this.staffRepository = staffRepository;
+        this.admissionApplicationRepository = admissionApplicationRepository;
+        this.studentAccessGuard = studentAccessGuard;
+        this.fileStorageService = fileStorageService;
+        this.contextPath = contextPath;
+    }
+
+    public DocumentAttachmentDTO upload(MultipartFile file, DocumentOwnerType ownerType, Long ownerId, User uploader) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("File is required and must not be empty");
+        }
+        if (file.getSize() > MAX_FILE_SIZE_BYTES) {
+            throw new IllegalArgumentException("File exceeds the " + (MAX_FILE_SIZE_BYTES / (1024 * 1024)) + "MB limit");
+        }
+        String extension = extensionOf(file.getOriginalFilename());
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            throw new IllegalArgumentException(
+                    "File type not allowed - accepted: " + String.join(", ", ALLOWED_EXTENSIONS));
+        }
+
+        enforceOwnerAccess(ownerType, ownerId, uploader, true);
+        resolveOwnerOrThrow(ownerType, ownerId);
+
+        String storedFileName = fileStorageService.store(file);
+        DocumentAttachment attachment = DocumentAttachment.builder()
+                .ownerType(ownerType)
+                .ownerId(ownerId)
+                .fileName(file.getOriginalFilename() != null ? file.getOriginalFilename() : storedFileName)
+                .storedFileName(storedFileName)
+                .fileType(extension)
+                .fileSize(file.getSize())
+                .uploadedBy(uploader)
+                .build();
+
+        try {
+            return mapToDTO(documentAttachmentRepository.save(attachment));
+        } catch (RuntimeException ex) {
+            // The file was already written to disk above; if the DB row never
+            // makes it (DB outage, unexpected constraint violation...) the
+            // @Transactional rollback undoes the insert but has no idea the
+            // file exists - clean it up here instead of leaking disk space.
+            fileStorageService.delete(storedFileName);
+            throw ex;
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public DocumentAttachmentDTO getById(Long id, User requester) {
+        DocumentAttachment attachment = findOrThrow(id);
+        enforceOwnerAccess(attachment.getOwnerType(), attachment.getOwnerId(), requester, false);
+        return mapToDTO(attachment);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DocumentAttachmentDTO> listByOwner(DocumentOwnerType ownerType, Long ownerId, User requester) {
+        enforceOwnerAccess(ownerType, ownerId, requester, false);
+        return documentAttachmentRepository.findByOwnerTypeAndOwnerIdOrderByUploadedAtDesc(ownerType, ownerId)
+                .stream().map(this::mapToDTO).collect(Collectors.toList());
+    }
+
+    /** @return the file bytes; caller (controller) is responsible for the Content-Disposition/type headers. */
+    @Transactional(readOnly = true)
+    public DocumentAttachment loadForDownload(Long id, User requester) {
+        DocumentAttachment attachment = findOrThrow(id);
+        enforceOwnerAccess(attachment.getOwnerType(), attachment.getOwnerId(), requester, false);
+        return attachment;
+    }
+
+    public Resource loadFileResource(String storedFileName) {
+        return fileStorageService.load(storedFileName);
+    }
+
+    public void delete(Long id, User requester) {
+        // Fails closed on a null requester, same as enforceOwnerAccess() below -
+        // the original `requester != null && ...` form let a null caller
+        // through with no check at all instead of being denied.
+        if (requester == null || (requester.getRole() != Role.ADMIN && requester.getRole() != Role.PRINCIPAL)) {
+            throw new AccessDeniedException("Only ADMIN/PRINCIPAL may delete a document attachment");
+        }
+        DocumentAttachment attachment = findOrThrow(id);
+        documentAttachmentRepository.delete(attachment);
+        fileStorageService.delete(attachment.getStoredFileName());
+    }
+
+    private DocumentAttachment findOrThrow(Long id) {
+        return documentAttachmentRepository.findByIdWithUploadedBy(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Document attachment not found with id: " + id));
+    }
+
+    private void resolveOwnerOrThrow(DocumentOwnerType ownerType, Long ownerId) {
+        boolean exists = switch (ownerType) {
+            case STUDENT -> studentRepository.existsById(ownerId);
+            case STAFF -> staffRepository.existsById(ownerId);
+            case ADMISSION_APPLICATION -> admissionApplicationRepository.existsById(ownerId);
+        };
+        if (!exists) {
+            throw new ResourceNotFoundException(ownerType + " not found with id: " + ownerId);
+        }
+    }
+
+    private void enforceOwnerAccess(DocumentOwnerType ownerType, Long ownerId, User requester, boolean isWrite) {
+        if (ownerType == DocumentOwnerType.STUDENT) {
+            studentAccessGuard.enforceCanAccessStudent(ownerId, requester);
+            return;
+        }
+        // STAFF / ADMISSION_APPLICATION: administrative records, no self-service
+        // caller - ADMIN/PRINCIPAL only (same restriction for read and write).
+        if (requester == null || (requester.getRole() != Role.ADMIN && requester.getRole() != Role.PRINCIPAL)) {
+            throw new AccessDeniedException(
+                    (isWrite ? "Uploading" : "Accessing") + " " + ownerType + " documents requires ADMIN or PRINCIPAL");
+        }
+    }
+
+    // Mirrors FileStorageService.extensionOf() exactly (including the
+    // non-alphanumeric strip) so the extension this whitelist check accepts
+    // and the extension actually written to the stored filename can never
+    // silently diverge.
+    private String extensionOf(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        int dot = originalFilename.lastIndexOf('.');
+        if (dot < 0 || dot == originalFilename.length() - 1) {
+            return "";
+        }
+        return originalFilename.substring(dot + 1).toLowerCase().replaceAll("[^a-z0-9]", "");
+    }
+
+    private DocumentAttachmentDTO mapToDTO(DocumentAttachment attachment) {
+        User uploadedBy = attachment.getUploadedBy();
+        return DocumentAttachmentDTO.builder()
+                .id(attachment.getId())
+                .ownerType(attachment.getOwnerType())
+                .ownerId(attachment.getOwnerId())
+                .fileName(attachment.getFileName())
+                .fileType(attachment.getFileType())
+                .fileSize(attachment.getFileSize())
+                .uploadedById(uploadedBy != null ? uploadedBy.getId() : null)
+                .uploadedByName(uploadedBy != null ? uploadedBy.getFirstName() + " " + uploadedBy.getLastName() : null)
+                .uploadedAt(attachment.getUploadedAt())
+                .downloadUrl(contextPath + "/v1/documents/" + attachment.getId() + "/download")
+                .build();
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/service/FileStorageService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/FileStorageService.java
@@ -1,0 +1,107 @@
+package com.schoolmanagement.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+/**
+ * Local-filesystem storage for {@link com.schoolmanagement.entity.DocumentAttachment}
+ * files, per IMPLEMENTATION_PLAN.md 3.9 (chose filesystem over MinIO — this
+ * app deploys as a single self-hosted instance, same reasoning as the
+ * in-memory admission rate limiter in 3.7; MinIO would add real
+ * infrastructure for a scaling need that doesn't exist yet).
+ *
+ * <p>Every stored filename is server-generated ({@link UUID}), never derived
+ * from the client-supplied original filename — accepting a client filename
+ * as-is (or embedding it in a path) is a classic path-traversal vector
+ * ("../../etc/passwd") and a collision risk. The original filename is kept
+ * only as {@link com.schoolmanagement.entity.DocumentAttachment#getFileName()}
+ * metadata, never touched by the filesystem layer.
+ */
+@Service
+public class FileStorageService {
+
+    @Value("${app.uploads.dir}")
+    private String uploadsDir;
+
+    private Path root;
+
+    @PostConstruct
+    void init() {
+        try {
+            root = Paths.get(uploadsDir).toAbsolutePath().normalize();
+            Files.createDirectories(root);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not create upload directory: " + uploadsDir, ex);
+        }
+    }
+
+    /** @return the generated stored filename (UUID + original extension, lower-cased). */
+    public String store(MultipartFile file) {
+        String extension = extensionOf(file.getOriginalFilename());
+        String storedFileName = UUID.randomUUID() + (extension.isEmpty() ? "" : "." + extension);
+
+        try {
+            Path target = root.resolve(storedFileName).normalize();
+            // Belt-and-braces: storedFileName is our own UUID, so this can't
+            // actually escape `root`, but a resolved path that ends up outside
+            // the upload directory is refused outright rather than trusted.
+            if (!target.startsWith(root)) {
+                throw new IllegalStateException("Resolved upload path escaped the upload directory");
+            }
+            Files.copy(file.getInputStream(), target);
+            return storedFileName;
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to store uploaded file", ex);
+        }
+    }
+
+    public Resource load(String storedFileName) {
+        try {
+            Path file = root.resolve(storedFileName).normalize();
+            if (!file.startsWith(root)) {
+                throw new IllegalStateException("Resolved download path escaped the upload directory");
+            }
+            Resource resource = new UrlResource(file.toUri());
+            if (!resource.exists() || !resource.isReadable()) {
+                throw new IllegalStateException("Stored file is missing or unreadable: " + storedFileName);
+            }
+            return resource;
+        } catch (MalformedURLException ex) {
+            throw new IllegalStateException("Failed to load stored file: " + storedFileName, ex);
+        }
+    }
+
+    public void delete(String storedFileName) {
+        try {
+            Path file = root.resolve(storedFileName).normalize();
+            if (!file.startsWith(root)) {
+                throw new IllegalStateException("Resolved delete path escaped the upload directory");
+            }
+            Files.deleteIfExists(file);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to delete stored file: " + storedFileName, ex);
+        }
+    }
+
+    private String extensionOf(String originalFilename) {
+        if (originalFilename == null) {
+            return "";
+        }
+        int dot = originalFilename.lastIndexOf('.');
+        if (dot < 0 || dot == originalFilename.length() - 1) {
+            return "";
+        }
+        return originalFilename.substring(dot + 1).toLowerCase().replaceAll("[^a-z0-9]", "");
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/service/GradeRecordService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/GradeRecordService.java
@@ -56,6 +56,7 @@ public class GradeRecordService {
     private AcademicYearRepository academicYearRepository;
     private StaffRepository staffRepository;
     private StudentAccessGuard studentAccessGuard;
+    private AuditLogService auditLogService;
 
     public GradeRecordDTO createGradeRecord(GradeRecord request) {
         GradeRecord record = GradeRecord.builder()
@@ -71,9 +72,11 @@ public class GradeRecordService {
         return mapToDTO(gradeRecordRepository.save(record));
     }
 
-    public GradeRecordDTO updateGradeRecord(Long id, GradeRecord request) {
+    public GradeRecordDTO updateGradeRecord(Long id, GradeRecord request, User actor) {
         GradeRecord record = gradeRecordRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Grade record not found with id: " + id));
+
+        Double previousScore = record.getScore();
 
         record.setStudent(resolveStudent(request.getStudent()));
         record.setSubject(resolveSubject(request.getSubject()));
@@ -83,7 +86,12 @@ public class GradeRecordService {
         record.setTeacher(resolveTeacher(request.getTeacher()));
         record.setRemarks(request.getRemarks());
 
-        return mapToDTO(gradeRecordRepository.save(record));
+        GradeRecordDTO result = mapToDTO(gradeRecordRepository.save(record));
+
+        auditLogService.log(actor, "UPDATE", "GradeRecord", id,
+                Map.of("previousScore", String.valueOf(previousScore), "newScore", String.valueOf(request.getScore())));
+
+        return result;
     }
 
     public GradeRecordDTO getGradeRecordById(Long id, User requester) {
@@ -93,10 +101,16 @@ public class GradeRecordService {
         return mapToDTO(record);
     }
 
-    public void deleteGradeRecord(Long id) {
+    public void deleteGradeRecord(Long id, User actor) {
         GradeRecord record = gradeRecordRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Grade record not found with id: " + id));
+        Long studentId = record.getStudent().getId();
+        Double score = record.getScore();
+
         gradeRecordRepository.delete(record);
+
+        auditLogService.log(actor, "DELETE", "GradeRecord", id,
+                Map.of("studentId", String.valueOf(studentId), "score", String.valueOf(score)));
     }
 
     public List<GradeRecordDTO> getStudentSemesterGrades(Long studentId, Long semesterId, User requester) {

--- a/backend/src/main/java/com/schoolmanagement/service/PasswordResetService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/PasswordResetService.java
@@ -1,0 +1,148 @@
+package com.schoolmanagement.service;
+
+import com.schoolmanagement.entity.PasswordResetToken;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.repository.PasswordResetTokenRepository;
+import com.schoolmanagement.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Forgot/reset password, per IMPLEMENTATION_PLAN.md 3.9. The raw token
+ * (256 bits of {@link SecureRandom}, URL-safe base64) is emailed once and
+ * never persisted — only its SHA-256 hash is stored (see
+ * {@link com.schoolmanagement.entity.PasswordResetToken}'s Javadoc) — so a
+ * database leak alone can't be used to reset anyone's password. Tokens
+ * expire after {@value #TOKEN_EXPIRY_MINUTES} minutes and are single-use.
+ */
+@Service
+@Transactional
+public class PasswordResetService {
+
+    private static final Logger log = LoggerFactory.getLogger(PasswordResetService.class);
+    private static final int TOKEN_EXPIRY_MINUTES = 15;
+
+    private final UserRepository userRepository;
+    private final PasswordResetTokenRepository passwordResetTokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailNotificationSender emailNotificationSender;
+    private final AuditLogService auditLogService;
+    private final String resetPasswordUrl;
+
+    // Not @AllArgsConstructor: Lombok's generated all-args constructor doesn't
+    // copy the @Value annotation onto its parameter, so Spring's constructor
+    // injection (the only injection mode when there's exactly one
+    // constructor) would try to autowire resetPasswordUrl as a `String` bean
+    // and fail to start the whole application context. @Value only works
+    // here because it's on an explicit constructor parameter.
+    public PasswordResetService(UserRepository userRepository,
+                                 PasswordResetTokenRepository passwordResetTokenRepository,
+                                 PasswordEncoder passwordEncoder,
+                                 EmailNotificationSender emailNotificationSender,
+                                 AuditLogService auditLogService,
+                                 @Value("${app.frontend.reset-password-url}") String resetPasswordUrl) {
+        this.userRepository = userRepository;
+        this.passwordResetTokenRepository = passwordResetTokenRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.emailNotificationSender = emailNotificationSender;
+        this.auditLogService = auditLogService;
+        this.resetPasswordUrl = resetPasswordUrl;
+    }
+
+    /**
+     * Always "succeeds" from the caller's point of view regardless of
+     * whether {@code email} matches an account — silently no-ops on a miss
+     * instead of a 404, so this endpoint can't be used to enumerate which
+     * emails are registered. See AuthController for the (identical either
+     * way) response it returns.
+     */
+    public void forgotPassword(String email) {
+        Optional<User> userOpt = userRepository.findByEmail(email);
+        if (userOpt.isEmpty()) {
+            return;
+        }
+        User user = userOpt.get();
+
+        // A newer request supersedes any still-outstanding one - an old email
+        // sitting in an inbox (or a compromised earlier link) shouldn't stay
+        // valid once the user has asked for a fresh one.
+        LocalDateTime now = LocalDateTime.now();
+        List<PasswordResetToken> outstanding = passwordResetTokenRepository.findByUserAndUsedAtIsNull(user);
+        outstanding.forEach(t -> t.setUsedAt(now));
+        passwordResetTokenRepository.saveAll(outstanding);
+
+        String rawToken = generateRawToken();
+        passwordResetTokenRepository.save(PasswordResetToken.builder()
+                .user(user)
+                .tokenHash(hash(rawToken))
+                .expiresAt(now.plusMinutes(TOKEN_EXPIRY_MINUTES))
+                .build());
+
+        String link = resetPasswordUrl + "?token=" + rawToken;
+        String content = "Xin chào " + user.getFirstName() + ",\n\n"
+                + "Nhấn vào liên kết sau để đặt lại mật khẩu (hết hạn sau " + TOKEN_EXPIRY_MINUTES + " phút):\n"
+                + link + "\n\n"
+                + "Nếu bạn không yêu cầu đặt lại mật khẩu, hãy bỏ qua email này — mật khẩu hiện tại vẫn giữ nguyên.";
+
+        // EmailNotificationSender.send() already catches MailException and
+        // returns false on failure - deliberately not treated as an error
+        // here either, for the same no-enumeration reason: whether the SMTP
+        // server is reachable is not something to leak to the caller.
+        boolean sent = emailNotificationSender.send(user.getEmail(), "Đặt lại mật khẩu", content);
+        if (!sent) {
+            log.warn("Failed to send password reset email to user {}", user.getId());
+        }
+    }
+
+    public void resetPassword(String rawToken, String newPassword) {
+        PasswordResetToken token = passwordResetTokenRepository.findByTokenHash(hash(rawToken))
+                .filter(t -> t.getUsedAt() == null)
+                .filter(t -> t.getExpiresAt().isAfter(LocalDateTime.now()))
+                // Same message whether the token is unknown, already used, or
+                // expired - distinguishing them would tell an attacker which
+                // guess was "closer".
+                .orElseThrow(() -> new IllegalArgumentException("Invalid or expired reset token"));
+
+        User user = token.getUser();
+        user.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        token.setUsedAt(LocalDateTime.now());
+        passwordResetTokenRepository.save(token);
+
+        auditLogService.log(user, "PASSWORD_RESET", "User", user.getId(), null);
+    }
+
+    private String generateRawToken() {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String hash(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(rawToken.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException ex) {
+            // SHA-256 is a JDK-guaranteed algorithm (JLS/JCA spec) - this is
+            // unreachable in practice, wrapped only so the method signature
+            // doesn't force every caller to handle a checked exception that
+            // can't actually occur.
+            throw new IllegalStateException("SHA-256 not available", ex);
+        }
+    }
+}

--- a/backend/src/main/java/com/schoolmanagement/service/StudentService.java
+++ b/backend/src/main/java/com/schoolmanagement/service/StudentService.java
@@ -1,10 +1,14 @@
 package com.schoolmanagement.service;
 
 import com.schoolmanagement.dto.StudentDTO;
+import com.schoolmanagement.entity.DocumentAttachment;
+import com.schoolmanagement.entity.DocumentOwnerType;
 import com.schoolmanagement.entity.Student;
 import com.schoolmanagement.entity.StudentStatus;
+import com.schoolmanagement.entity.User;
 import com.schoolmanagement.exception.DuplicateResourceException;
 import com.schoolmanagement.exception.ResourceNotFoundException;
+import com.schoolmanagement.repository.DocumentAttachmentRepository;
 import com.schoolmanagement.repository.StudentRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -13,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -21,6 +26,9 @@ import java.util.stream.Collectors;
 public class StudentService {
 
     private StudentRepository studentRepository;
+    private AuditLogService auditLogService;
+    private DocumentAttachmentRepository documentAttachmentRepository;
+    private FileStorageService fileStorageService;
 
     public StudentDTO createStudent(Student student) {
         if (studentRepository.existsByRollNumber(student.getRollNumber())) {
@@ -120,10 +128,24 @@ public class StudentService {
                 .collect(Collectors.toList());
     }
 
-    public void deleteStudent(Long id) {
+    public void deleteStudent(Long id, User actor) {
         Student student = studentRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Student not found with id: " + id));
+        String rollNumber = student.getRollNumber();
+
+        // document_attachments.owner_id has no FK to students (it's polymorphic
+        // - see DocumentOwnerType) so nothing at the DB level would catch this:
+        // without cleaning these up first, deleting the student would silently
+        // leave orphaned DocumentAttachment rows and their files on disk with
+        // no owner and no code path that will ever remove them.
+        List<DocumentAttachment> documents = documentAttachmentRepository
+                .findByOwnerTypeAndOwnerIdOrderByUploadedAtDesc(DocumentOwnerType.STUDENT, id);
+        documentAttachmentRepository.deleteAll(documents);
+        documents.forEach(doc -> fileStorageService.delete(doc.getStoredFileName()));
+
         studentRepository.delete(student);
+
+        auditLogService.log(actor, "DELETE", "Student", id, Map.of("rollNumber", rollNumber));
     }
 
     private StudentDTO mapToDTO(Student student) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,6 +24,13 @@ spring:
       write-dates-as-timestamps: false
     default-property-inclusion: non_null
 
+  # Document attachment uploads (3.9) - server rejects anything over this
+  # before DocumentService's own MAX_FILE_SIZE_BYTES check even runs.
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
   # Email (sổ liên lạc điện tử, 3.6 EMAIL channel). Unlike JWT_SECRET this has
   # defaults and doesn't fail startup if unconfigured — an unreachable/absent
   # SMTP server just makes EmailNotificationSender.send() fail per-recipient
@@ -66,6 +73,20 @@ app:
       # header to dodge the limit. Default false rate-limits by the real TCP
       # peer address instead.
       trust-forwarded-for: ${ADMISSION_TRUST_FORWARDED_FOR:false}
+  auth:
+    forgot-password-rate-limit:
+      max-requests: ${FORGOT_PASSWORD_RATE_LIMIT_MAX:3}
+      window-minutes: ${FORGOT_PASSWORD_RATE_LIMIT_WINDOW_MINUTES:60}
+      trust-forwarded-for: ${ADMISSION_TRUST_FORWARDED_FOR:false}
+  frontend:
+    # Where the reset-password link in the forgot-password email points -
+    # a real frontend route that reads ?token= and calls POST /v1/auth/reset-password.
+    reset-password-url: ${FRONTEND_RESET_PASSWORD_URL:http://localhost:3000/reset-password}
+  uploads:
+    # Local filesystem directory for DocumentAttachment files (3.9) - chose
+    # filesystem over MinIO/S3, see FileStorageService's Javadoc. Resolved to
+    # an absolute path at startup; created if missing.
+    dir: ${UPLOAD_DIR:./uploads}
 
 # Swagger/API Documentation
 springdoc:

--- a/backend/src/main/resources/db/migration/V10__shared_infra.sql
+++ b/backend/src/main/resources/db/migration/V10__shared_infra.sql
@@ -1,0 +1,55 @@
+-- =====================================================
+-- Phase 3.9: Hạ tầng dùng chung (document attachments,
+-- audit log, forgot/reset password).
+-- =====================================================
+-- No backfill in any of these three - nothing pre-3.9 represented file
+-- attachments, an audit trail, or password-reset tokens.
+-- =====================================================
+
+CREATE TABLE `document_attachments` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `owner_type` enum('STUDENT','STAFF','ADMISSION_APPLICATION') NOT NULL,
+  `owner_id` bigint NOT NULL,
+  `file_name` varchar(255) NOT NULL,
+  `stored_file_name` varchar(255) NOT NULL,
+  `file_type` varchar(100) NOT NULL,
+  `file_size` bigint NOT NULL,
+  `uploaded_by_id` bigint NOT NULL,
+  `uploaded_at` datetime(6) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_document_attachments_stored_file_name` (`stored_file_name`),
+  KEY `idx_document_attachments_owner` (`owner_type`, `owner_id`),
+  KEY `fk_document_attachments_uploaded_by` (`uploaded_by_id`),
+  CONSTRAINT `fk_document_attachments_uploaded_by` FOREIGN KEY (`uploaded_by_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `audit_logs` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `actor_id` bigint NOT NULL,
+  `action` varchar(50) NOT NULL,
+  `entity_type` varchar(100) NOT NULL,
+  `entity_id` bigint DEFAULT NULL,
+  `occurred_at` datetime(6) NOT NULL,
+  `detail_json` text,
+  PRIMARY KEY (`id`),
+  KEY `idx_audit_logs_entity` (`entity_type`, `entity_id`),
+  KEY `idx_audit_logs_actor` (`actor_id`),
+  KEY `idx_audit_logs_occurred_at` (`occurred_at`),
+  CONSTRAINT `fk_audit_logs_actor` FOREIGN KEY (`actor_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `password_reset_tokens` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `user_id` bigint NOT NULL,
+  -- SHA-256 hash of the token, not the raw token - a DB leak alone must not
+  -- be enough to reset anyone's password. The raw token only ever exists in
+  -- the outgoing email and the incoming reset request.
+  `token_hash` varchar(64) NOT NULL,
+  `expires_at` datetime(6) NOT NULL,
+  `used_at` datetime(6) DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_password_reset_tokens_token_hash` (`token_hash`),
+  KEY `fk_password_reset_tokens_user` (`user_id`),
+  CONSTRAINT `fk_password_reset_tokens_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/src/test/java/com/schoolmanagement/controller/AdmissionIntegrationTest.java
+++ b/backend/src/test/java/com/schoolmanagement/controller/AdmissionIntegrationTest.java
@@ -60,27 +60,39 @@ class AdmissionIntegrationTest {
     private StudentRepository studentRepository;
     @Autowired
     private UserRepository userRepository;
-
-    /**
-     * @WithMockUser's SecurityContext lives on the test method's own thread
-     * (ThreadLocal) — invisible to the pool threads the concurrency test
-     * below dispatches MockMvc calls from. Attaching authentication directly
-     * to each request like this works regardless of which thread executes it.
-     * Transient (unsaved) principal — fine wherever the endpoint only checks
-     * @PreAuthorize and never persists a reference to the caller (approve-and-
-     * create takes no Authentication at all). Endpoints that do persist the
-     * caller (e.g. updateStatus's reviewedBy) need asUser() with a real,
-     * already-saved User instead — a transient one has no id to put in the FK.
-     */
-    private RequestPostProcessor asAdmin() {
-        User admin = User.builder().role(Role.ADMIN).username("itest-admin-principal").build();
-        return authentication(new UsernamePasswordAuthenticationToken(
-                admin, null, java.util.List.of(new SimpleGrantedAuthority("ROLE_ADMIN"))));
-    }
+    @Autowired
+    private com.schoolmanagement.repository.AuditLogRepository auditLogRepository;
 
     private RequestPostProcessor asUser(User user, String role) {
         return authentication(new UsernamePasswordAuthenticationToken(
                 user, null, java.util.List.of(new SimpleGrantedAuthority("ROLE_" + role))));
+    }
+
+    /**
+     * approve-and-create now audits itself (3.9) — AuditLogService persists
+     * an AuditLog row whose actor FK must reference a real, already-saved
+     * User, so every caller (including the two NOT_SUPPORTED concurrency
+     * tests below, whose SecurityContext isn't visible to their pool threads
+     * anyway — see their own Javadoc) needs a real persisted admin now, not
+     * a transient principal.
+     */
+    /**
+     * The NOT_SUPPORTED tests' admin user is real/persisted (see saveAdmin's
+     * Javadoc) - a successful approve-and-create through it leaves a real
+     * AuditLog row with an FK to that user, which must be deleted before the
+     * user itself can be (no ON DELETE CASCADE on audit_logs.actor_id).
+     */
+    private void deleteAuditLogsFor(User actor) {
+        auditLogRepository.deleteAll(
+                auditLogRepository.search(null, actor.getId(), org.springframework.data.domain.Pageable.unpaged()).getContent());
+    }
+
+    private User saveAdmin(String usernameSuffix) {
+        return userRepository.save(User.builder()
+                .username("itest.admission.admin." + usernameSuffix)
+                .email("itest.admission.admin." + usernameSuffix + "@school.com")
+                .password("{noop}Str0ngPassw0rd!")
+                .firstName("Integration").lastName("Admin").role(Role.ADMIN).enabled(true).build());
     }
 
     private String submitPayload(String phone, int gradeLevel) throws Exception {
@@ -237,24 +249,26 @@ class AdmissionIntegrationTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
     void approveAndCreate_beforeApproved_returns400() throws Exception {
         AdmissionApplication application = admissionApplicationRepository.save(newApplication("ITEST NotApproved"));
+        User admin = saveAdmin("beforeapproved");
 
         mockMvc.perform(post("/v1/admissions/{id}/approve-and-create", application.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(approveRequest("itest.notapproved"))))
+                        .content(objectMapper.writeValueAsString(approveRequest("itest.notapproved")))
+                        .with(asUser(admin, "ADMIN")))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
     void approveAndCreate_persistsUserAndStudentFromApplicationData() throws Exception {
         AdmissionApplication application = admissionApplicationRepository.save(approvedApplication("Tran Thi ITEST"));
+        User admin = saveAdmin("persists");
 
         mockMvc.perform(post("/v1/admissions/{id}/approve-and-create", application.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(approveRequest("itest.approved1"))))
+                        .content(objectMapper.writeValueAsString(approveRequest("itest.approved1")))
+                        .with(asUser(admin, "ADMIN")))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.username").value("itest.approved1"))
                 .andExpect(jsonPath("$.rollNumber").value("ITEST-ROLL-1"));
@@ -268,23 +282,24 @@ class AdmissionIntegrationTest {
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
     void approveAndCreate_secondAttempt_returns409() throws Exception {
         AdmissionApplication application = admissionApplicationRepository.save(approvedApplication("ITEST Twice"));
+        User admin = saveAdmin("twice");
 
         mockMvc.perform(post("/v1/admissions/{id}/approve-and-create", application.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(approveRequest("itest.twice1"))))
+                        .content(objectMapper.writeValueAsString(approveRequest("itest.twice1")))
+                        .with(asUser(admin, "ADMIN")))
                 .andExpect(status().isCreated());
 
         mockMvc.perform(post("/v1/admissions/{id}/approve-and-create", application.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(approveRequest("itest.twice2"))))
+                        .content(objectMapper.writeValueAsString(approveRequest("itest.twice2")))
+                        .with(asUser(admin, "ADMIN")))
                 .andExpect(status().isConflict());
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
     void approveAndCreate_duplicateUsername_returns409() throws Exception {
         // Own dedicated User, not a hardcoded seeded username ("admin") - this
         // test previously assumed TEST_DATA_CORRECTED.sql had already been run
@@ -295,11 +310,13 @@ class AdmissionIntegrationTest {
                 .password("{noop}Str0ngPassw0rd!")
                 .firstName("Existing").lastName("User").role(Role.ADMIN).enabled(true).build());
         AdmissionApplication application = admissionApplicationRepository.save(approvedApplication("ITEST DupUser"));
+        User admin = saveAdmin("dupusername");
         ApproveAndCreateRequest request = approveRequest("itest.existing.username");
 
         mockMvc.perform(post("/v1/admissions/{id}/approve-and-create", application.getId())
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(asUser(admin, "ADMIN")))
                 .andExpect(status().isConflict());
     }
 
@@ -324,6 +341,10 @@ class AdmissionIntegrationTest {
         Long firstId = first.getId();
         Long secondId = second.getId();
         String sharedRollNumber = "ITEST-ROLL-RACE";
+        // NOT_SUPPORTED suspends this test's transaction entirely, so this save
+        // is NOT auto-rolled-back either - cleaned up in the finally block below
+        // alongside the rest of this test's manually-tracked rows.
+        User admin = saveAdmin("rolldup-" + System.nanoTime());
 
         ExecutorService pool = Executors.newFixedThreadPool(2);
         CountDownLatch ready = new CountDownLatch(2);
@@ -347,7 +368,7 @@ class AdmissionIntegrationTest {
                 int status = mockMvc.perform(post("/v1/admissions/{id}/approve-and-create", applicationId)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
-                                .with(asAdmin()))
+                                .with(asUser(admin, "ADMIN")))
                         .andReturn().getResponse().getStatus();
                 if (status == 201) {
                     successCount.incrementAndGet();
@@ -374,6 +395,8 @@ class AdmissionIntegrationTest {
             studentRepository.findByRollNumber(sharedRollNumber).ifPresent(studentRepository::delete);
             usernamesToCleanUp.forEach(username ->
                     userRepository.findByUsername(username).ifPresent(userRepository::delete));
+            deleteAuditLogsFor(admin);
+            userRepository.delete(admin);
         }
     }
 
@@ -403,6 +426,7 @@ class AdmissionIntegrationTest {
     void approveAndCreate_concurrentCalls_onlyOneSucceeds() throws Exception {
         AdmissionApplication application = admissionApplicationRepository.save(approvedApplication("ITEST Concurrent"));
         Long applicationId = application.getId();
+        User admin = saveAdmin("concurrent-" + System.nanoTime());
 
         ExecutorService pool = Executors.newFixedThreadPool(2);
         CountDownLatch ready = new CountDownLatch(2);
@@ -434,7 +458,7 @@ class AdmissionIntegrationTest {
                 int status = mockMvc.perform(post("/v1/admissions/{id}/approve-and-create", applicationId)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
-                                .with(asAdmin()))
+                                .with(asUser(admin, "ADMIN")))
                         .andReturn().getResponse().getStatus();
                 if (status == 201) {
                     successCount.incrementAndGet();
@@ -462,6 +486,8 @@ class AdmissionIntegrationTest {
                     studentRepository.findByRollNumber(roll).ifPresent(studentRepository::delete));
             usernamesToCleanUp.forEach(username ->
                     userRepository.findByUsername(username).ifPresent(userRepository::delete));
+            deleteAuditLogsFor(admin);
+            userRepository.delete(admin);
         }
     }
 

--- a/backend/src/test/java/com/schoolmanagement/controller/AuditLogIntegrationTest.java
+++ b/backend/src/test/java/com/schoolmanagement/controller/AuditLogIntegrationTest.java
@@ -1,0 +1,201 @@
+package com.schoolmanagement.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schoolmanagement.entity.EmploymentStatus;
+import com.schoolmanagement.entity.GradeComponentType;
+import com.schoolmanagement.entity.GradeRecord;
+import com.schoolmanagement.entity.Role;
+import com.schoolmanagement.entity.Semester;
+import com.schoolmanagement.entity.SemesterName;
+import com.schoolmanagement.entity.AcademicYear;
+import com.schoolmanagement.entity.AcademicYearStatus;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.StaffPosition;
+import com.schoolmanagement.entity.Student;
+import com.schoolmanagement.entity.StudentStatus;
+import com.schoolmanagement.entity.Subject;
+import com.schoolmanagement.entity.SubjectCategory;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.repository.AcademicYearRepository;
+import com.schoolmanagement.repository.GradeRecordRepository;
+import com.schoolmanagement.repository.SemesterRepository;
+import com.schoolmanagement.repository.StaffRepository;
+import com.schoolmanagement.repository.StudentRepository;
+import com.schoolmanagement.repository.SubjectRepository;
+import com.schoolmanagement.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration test for /v1/audit-logs and the manual audit call sites it
+ * reads from — real Spring context + local MySQL via the "test" profile.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class AuditLogIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private AcademicYearRepository academicYearRepository;
+    @Autowired
+    private SemesterRepository semesterRepository;
+    @Autowired
+    private SubjectRepository subjectRepository;
+    @Autowired
+    private StudentRepository studentRepository;
+    @Autowired
+    private StaffRepository staffRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private GradeRecordRepository gradeRecordRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private Semester hk1;
+    private Subject subject;
+    private Student student;
+    private Staff staff;
+    private User adminUser;
+
+    @BeforeEach
+    void setUp() {
+        AcademicYear academicYear = academicYearRepository.save(AcademicYear.builder()
+                .name("2099-2100").startDate(LocalDate.of(2099, 9, 1)).endDate(LocalDate.of(2100, 5, 31))
+                .status(AcademicYearStatus.ACTIVE).build());
+        hk1 = semesterRepository.save(Semester.builder()
+                .academicYear(academicYear).name(SemesterName.HK1)
+                .startDate(academicYear.getStartDate()).endDate(LocalDate.of(2100, 1, 15)).build());
+        subject = subjectRepository.save(Subject.builder()
+                .code("ITEST-AUDIT-SUBJ").name("ITEST Subject").category(SubjectCategory.BAT_BUOC).build());
+
+        User teacherUser = userRepository.save(User.builder()
+                .username("itest.audit.teacher").email("itest.audit.teacher@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Teacher").role(Role.TEACHER).enabled(true).build());
+        staff = staffRepository.save(Staff.builder()
+                .employeeId("ITEST-AUDIT-EMP").user(teacherUser)
+                .position(StaffPosition.TEACHER).status(EmploymentStatus.ACTIVE).build());
+
+        User studentUser = userRepository.save(User.builder()
+                .username("itest.audit.student").email("itest.audit.student@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Student").role(Role.STUDENT).enabled(true).build());
+        student = studentRepository.save(Student.builder()
+                .rollNumber("ITEST-AUDIT-ROLL").admissionNumber("ITEST-AUDIT-ADM")
+                .user(studentUser).status(StudentStatus.ACTIVE).build());
+
+        adminUser = userRepository.save(User.builder()
+                .username("itest.audit.admin").email("itest.audit.admin@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Admin").role(Role.ADMIN).enabled(true).build());
+    }
+
+    private RequestPostProcessor asUser(User user, String role) {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                user, null, List.of(new SimpleGrantedAuthority("ROLE_" + role))));
+    }
+
+    @Test
+    void updateGradeRecord_writesAuditLogEntry() throws Exception {
+        GradeRecord record = gradeRecordRepository.save(GradeRecord.builder()
+                .student(student).subject(subject).semester(hk1)
+                .componentType(GradeComponentType.MIENG).score(7.0).teacher(staff).build());
+
+        GradeRecord update = GradeRecord.builder()
+                .student(Student.builder().id(student.getId()).build())
+                .subject(Subject.builder().id(subject.getId()).build())
+                .semester(Semester.builder().id(hk1.getId()).build())
+                .componentType(GradeComponentType.MIENG).score(9.0)
+                .teacher(Staff.builder().id(staff.getId()).build())
+                .build();
+
+        mockMvc.perform(put("/v1/grade-records/{id}", record.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(update))
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/v1/audit-logs")
+                        .param("entityType", "GradeRecord")
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.entityId == " + record.getId() + " && @.action == 'UPDATE')]").exists())
+                .andExpect(jsonPath("$.content[0].actorName").value("Integration Admin"));
+    }
+
+    @Test
+    void deleteGradeRecord_writesAuditLogEntry() throws Exception {
+        GradeRecord record = gradeRecordRepository.save(GradeRecord.builder()
+                .student(student).subject(subject).semester(hk1)
+                .componentType(GradeComponentType.MIENG).score(7.0).teacher(staff).build());
+
+        mockMvc.perform(delete("/v1/grade-records/{id}", record.getId())
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/v1/audit-logs")
+                        .param("entityType", "GradeRecord")
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.entityId == " + record.getId() + " && @.action == 'DELETE')]").exists());
+    }
+
+    @Test
+    void deleteStudent_writesAuditLogEntry() throws Exception {
+        mockMvc.perform(delete("/v1/students/{id}", student.getId())
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(get("/v1/audit-logs")
+                        .param("entityType", "Student")
+                        .param("actorId", adminUser.getId().toString())
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[?(@.entityId == " + student.getId() + " && @.action == 'DELETE')]").exists());
+    }
+
+    @Test
+    void search_asNonAdmin_returns403() throws Exception {
+        mockMvc.perform(get("/v1/audit-logs").with(asUser(staff.getUser(), "TEACHER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void search_sizeOverLimit_returns400() throws Exception {
+        mockMvc.perform(get("/v1/audit-logs").param("size", "500"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void search_negativePage_returns400() throws Exception {
+        mockMvc.perform(get("/v1/audit-logs").param("page", "-1"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/com/schoolmanagement/controller/DocumentIntegrationTest.java
+++ b/backend/src/test/java/com/schoolmanagement/controller/DocumentIntegrationTest.java
@@ -1,0 +1,291 @@
+package com.schoolmanagement.controller;
+
+import com.schoolmanagement.entity.DocumentOwnerType;
+import com.schoolmanagement.entity.EmploymentStatus;
+import com.schoolmanagement.entity.Role;
+import com.schoolmanagement.entity.Staff;
+import com.schoolmanagement.entity.StaffPosition;
+import com.schoolmanagement.entity.Student;
+import com.schoolmanagement.entity.StudentStatus;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.entity.DocumentAttachment;
+import com.schoolmanagement.repository.DocumentAttachmentRepository;
+import com.schoolmanagement.repository.StaffRepository;
+import com.schoolmanagement.repository.StudentRepository;
+import com.schoolmanagement.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Integration test for /v1/documents — real Spring context + local MySQL via
+ * the "test" profile. FileStorageService writes real files under
+ * app.uploads.dir (overridden to ./uploads/test for the whole test profile
+ * so this never touches real dev uploads) - deleted per test in @AfterEach-
+ * style cleanup isn't needed since DocumentService.delete() removes the file
+ * for the tests that call it, and @Transactional rollback handles the DB
+ * row either way; any file left behind by a non-delete test is orphaned but
+ * harmless test-directory clutter, not a correctness issue.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class DocumentIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private StudentRepository studentRepository;
+    @Autowired
+    private StaffRepository staffRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private DocumentAttachmentRepository documentAttachmentRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+    @Value("${app.uploads.dir}")
+    private String uploadsDir;
+
+    private Student student;
+    private Student otherStudent;
+    private Staff staff;
+    private User studentUser;
+    private User otherStudentUser;
+    private User adminUser;
+    private User teacherUser;
+
+    @BeforeEach
+    void setUp() {
+        adminUser = userRepository.save(User.builder()
+                .username("itest.doc.admin").email("itest.doc.admin@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Admin").role(Role.ADMIN).enabled(true).build());
+        teacherUser = userRepository.save(User.builder()
+                .username("itest.doc.teacher").email("itest.doc.teacher@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Teacher").role(Role.TEACHER).enabled(true).build());
+        staff = staffRepository.save(Staff.builder()
+                .employeeId("ITEST-DOC-EMP").user(teacherUser)
+                .position(StaffPosition.TEACHER).status(EmploymentStatus.ACTIVE).build());
+
+        studentUser = userRepository.save(User.builder()
+                .username("itest.doc.student").email("itest.doc.student@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("Student").role(Role.STUDENT).enabled(true).build());
+        student = studentRepository.save(Student.builder()
+                .rollNumber("ITEST-DOC-ROLL").admissionNumber("ITEST-DOC-ADM")
+                .user(studentUser).status(StudentStatus.ACTIVE).build());
+
+        otherStudentUser = userRepository.save(User.builder()
+                .username("itest.doc.student2").email("itest.doc.student2@school.com")
+                .password(passwordEncoder.encode("Str0ngPassw0rd!"))
+                .firstName("Integration").lastName("StudentTwo").role(Role.STUDENT).enabled(true).build());
+        otherStudent = studentRepository.save(Student.builder()
+                .rollNumber("ITEST-DOC-ROLL-2").admissionNumber("ITEST-DOC-ADM-2")
+                .user(otherStudentUser).status(StudentStatus.ACTIVE).build());
+    }
+
+    private RequestPostProcessor asUser(User user, String role) {
+        return authentication(new UsernamePasswordAuthenticationToken(
+                user, null, List.of(new SimpleGrantedAuthority("ROLE_" + role))));
+    }
+
+    private MockMultipartFile pdfFile() {
+        return new MockMultipartFile("file", "hoso.pdf", "application/pdf", "fake pdf content".getBytes());
+    }
+
+    @Test
+    void upload_asAdminForStudent_succeeds() throws Exception {
+        mockMvc.perform(multipart("/v1/documents")
+                        .file(pdfFile())
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", student.getId().toString())
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.fileName").value("hoso.pdf"))
+                .andExpect(jsonPath("$.fileType").value("pdf"))
+                .andExpect(jsonPath("$.downloadUrl").exists());
+    }
+
+    @Test
+    void upload_invalidExtension_returns400() throws Exception {
+        MockMultipartFile exeFile = new MockMultipartFile("file", "virus.exe", "application/octet-stream", "x".getBytes());
+        mockMvc.perform(multipart("/v1/documents")
+                        .file(exeFile)
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", student.getId().toString())
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void upload_nonexistentStudentOwner_returns404() throws Exception {
+        mockMvc.perform(multipart("/v1/documents")
+                        .file(pdfFile())
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", "9999999")
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void upload_asOwningStudent_succeeds() throws Exception {
+        mockMvc.perform(multipart("/v1/documents")
+                        .file(pdfFile())
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", student.getId().toString())
+                        .with(asUser(studentUser, "STUDENT")))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void upload_asDifferentStudent_returns403() throws Exception {
+        mockMvc.perform(multipart("/v1/documents")
+                        .file(pdfFile())
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", student.getId().toString())
+                        .with(asUser(otherStudentUser, "STUDENT")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void upload_staffOwnerAsTeacher_returns403() throws Exception {
+        // STAFF-owned documents are ADMIN/PRINCIPAL only - even the staff
+        // member's own TEACHER account can't upload against their own record.
+        mockMvc.perform(multipart("/v1/documents")
+                        .file(pdfFile())
+                        .param("ownerType", "STAFF")
+                        .param("ownerId", staff.getId().toString())
+                        .with(asUser(teacherUser, "TEACHER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void upload_staffOwnerAsAdmin_succeeds() throws Exception {
+        mockMvc.perform(multipart("/v1/documents")
+                        .file(pdfFile())
+                        .param("ownerType", "STAFF")
+                        .param("ownerId", staff.getId().toString())
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void listByOwner_asOwningStudent_returnsUploaded() throws Exception {
+        mockMvc.perform(multipart("/v1/documents")
+                        .file(pdfFile())
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", student.getId().toString())
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(get("/v1/documents")
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", student.getId().toString())
+                        .with(asUser(studentUser, "STUDENT")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].fileName").value("hoso.pdf"));
+    }
+
+    @Test
+    void listByOwner_asDifferentStudent_returns403() throws Exception {
+        mockMvc.perform(get("/v1/documents")
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", student.getId().toString())
+                        .with(asUser(otherStudentUser, "STUDENT")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void downloadAndDelete_roundTrip() throws Exception {
+        String body = mockMvc.perform(multipart("/v1/documents")
+                        .file(pdfFile())
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", student.getId().toString())
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long id = Long.valueOf(body.replaceAll(".*\"id\":(\\d+).*", "$1"));
+
+        byte[] downloaded = mockMvc.perform(get("/v1/documents/{id}/download", id)
+                        .with(asUser(studentUser, "STUDENT")))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsByteArray();
+        Assertions.assertArrayEquals("fake pdf content".getBytes(), downloaded);
+
+        // STUDENT may read/download but not delete - only ADMIN/PRINCIPAL can.
+        mockMvc.perform(delete("/v1/documents/{id}", id).with(asUser(studentUser, "STUDENT")))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(delete("/v1/documents/{id}", id).with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isNoContent());
+
+        Assertions.assertTrue(documentAttachmentRepository.findById(id).isEmpty());
+    }
+
+    @Test
+    void deleteStudent_alsoDeletesTheirDocumentAttachmentsAndFiles() throws Exception {
+        // document_attachments.owner_id has no FK to students (it's
+        // polymorphic - see DocumentOwnerType), so nothing at the DB level
+        // would catch an orphaned row/file left behind by a naive student
+        // delete. Regression test for that self-review finding.
+        String body = mockMvc.perform(multipart("/v1/documents")
+                        .file(pdfFile())
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", student.getId().toString())
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long docId = Long.valueOf(body.replaceAll(".*\"id\":(\\d+).*", "$1"));
+        DocumentAttachment attachment = documentAttachmentRepository.findByIdWithUploadedBy(docId).orElseThrow();
+        Path storedFile = Paths.get(uploadsDir).resolve(attachment.getStoredFileName());
+        Assertions.assertTrue(Files.exists(storedFile), "precondition: the uploaded file must exist on disk");
+
+        mockMvc.perform(delete("/v1/students/{id}", student.getId()).with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isNoContent());
+
+        Assertions.assertTrue(documentAttachmentRepository.findById(docId).isEmpty(),
+                "the DocumentAttachment row must be gone, not left orphaned");
+        Assertions.assertFalse(Files.exists(storedFile), "the physical file must be deleted too, not just the DB row");
+    }
+
+    @Test
+    void download_asDifferentStudent_returns403() throws Exception {
+        String body = mockMvc.perform(multipart("/v1/documents")
+                        .file(pdfFile())
+                        .param("ownerType", "STUDENT")
+                        .param("ownerId", student.getId().toString())
+                        .with(asUser(adminUser, "ADMIN")))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        Long id = Long.valueOf(body.replaceAll(".*\"id\":(\\d+).*", "$1"));
+
+        mockMvc.perform(get("/v1/documents/{id}/download", id).with(asUser(otherStudentUser, "STUDENT")))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/backend/src/test/java/com/schoolmanagement/controller/ForgotPasswordRateLimitIntegrationTest.java
+++ b/backend/src/test/java/com/schoolmanagement/controller/ForgotPasswordRateLimitIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.schoolmanagement.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schoolmanagement.dto.ForgotPasswordRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Dedicated test for ForgotPasswordRateLimitFilter's 429 behavior, isolated
+ * from other tests hitting /v1/auth/forgot-password for the same reason
+ * AdmissionRateLimitIntegrationTest is isolated from AdmissionIntegrationTest
+ * — see that class's Javadoc.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = "app.auth.forgot-password-rate-limit.max-requests=2")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class ForgotPasswordRateLimitIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String payload(String email) throws Exception {
+        return objectMapper.writeValueAsString(ForgotPasswordRequest.builder().email(email).build());
+    }
+
+    @Test
+    void thirdRequestFromSameIpWithinWindow_returns429() throws Exception {
+        // Doesn't matter that none of these emails exist - the rate limiter
+        // runs before the (also-generic-either-way) service logic.
+        mockMvc.perform(post("/v1/auth/forgot-password").contentType(MediaType.APPLICATION_JSON).content(payload("itest.rl1@school.com")))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/v1/auth/forgot-password").contentType(MediaType.APPLICATION_JSON).content(payload("itest.rl2@school.com")))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/v1/auth/forgot-password").contentType(MediaType.APPLICATION_JSON).content(payload("itest.rl3@school.com")))
+                .andExpect(status().is(429));
+    }
+}

--- a/backend/src/test/java/com/schoolmanagement/controller/PasswordResetIntegrationTest.java
+++ b/backend/src/test/java/com/schoolmanagement/controller/PasswordResetIntegrationTest.java
@@ -1,0 +1,211 @@
+package com.schoolmanagement.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.schoolmanagement.dto.ForgotPasswordRequest;
+import com.schoolmanagement.dto.ResetPasswordRequest;
+import com.schoolmanagement.entity.PasswordResetToken;
+import com.schoolmanagement.entity.Role;
+import com.schoolmanagement.entity.User;
+import com.schoolmanagement.repository.PasswordResetTokenRepository;
+import com.schoolmanagement.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration test for /v1/auth/forgot-password and /v1/auth/reset-password
+ * — real Spring context + local MySQL via the "test" profile. Rate-limiting
+ * itself is tested separately (ForgotPasswordRateLimitIntegrationTest), same
+ * reasoning as AdmissionIntegrationTest/AdmissionRateLimitIntegrationTest.
+ *
+ * <p>reset-password tests insert a {@link PasswordResetToken} directly
+ * (hashing a known raw token the same way {@code PasswordResetService} does)
+ * rather than going through forgotPassword() first — the real raw token only
+ * ever exists in the outgoing email body, which this test doesn't intercept
+ * (see PasswordResetService's Javadoc on why only the hash is persisted).
+ * This still exercises the real resetPassword() logic end-to-end via HTTP;
+ * it just supplies the token forgotPassword() would otherwise have emailed.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class PasswordResetIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private PasswordResetTokenRepository passwordResetTokenRepository;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(User.builder()
+                .username("itest.pwreset.user").email("itest.pwreset.user@school.com")
+                .password(passwordEncoder.encode("OldPassw0rd!"))
+                .firstName("Integration").lastName("User").role(Role.STUDENT).enabled(true).build());
+    }
+
+    // ---------------------------------------------------------------
+    // forgot-password
+    // ---------------------------------------------------------------
+
+    @Test
+    void forgotPassword_existingEmail_createsToken() throws Exception {
+        mockMvc.perform(post("/v1/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                ForgotPasswordRequest.builder().email(user.getEmail()).build())))
+                .andExpect(status().isOk());
+
+        List<PasswordResetToken> tokens = passwordResetTokenRepository.findByUserAndUsedAtIsNull(user);
+        Assertions.assertEquals(1, tokens.size());
+        Assertions.assertTrue(tokens.get(0).getExpiresAt().isAfter(LocalDateTime.now()));
+        Assertions.assertTrue(tokens.get(0).getExpiresAt().isBefore(LocalDateTime.now().plusMinutes(16)));
+    }
+
+    @Test
+    void forgotPassword_nonexistentEmail_returnsGenericResponseNoToken() throws Exception {
+        // Same 200 + same generic message as the existing-email case above -
+        // this is what actually prevents email enumeration; a differing
+        // response (or a 404) would leak which addresses are registered.
+        mockMvc.perform(post("/v1/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                ForgotPasswordRequest.builder().email("itest.nonexistent@school.com").build())))
+                .andExpect(status().isOk());
+
+        Assertions.assertTrue(passwordResetTokenRepository.findAll().stream()
+                .noneMatch(t -> t.getUser() != null && "itest.nonexistent@school.com".equals(t.getUser().getEmail())));
+    }
+
+    @Test
+    void forgotPassword_secondRequestInvalidatesFirstToken() throws Exception {
+        mockMvc.perform(post("/v1/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                ForgotPasswordRequest.builder().email(user.getEmail()).build())))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/v1/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                ForgotPasswordRequest.builder().email(user.getEmail()).build())))
+                .andExpect(status().isOk());
+
+        // The first token is superseded (usedAt set) the moment a second is
+        // requested - only the newest should still be outstanding.
+        Assertions.assertEquals(1, passwordResetTokenRepository.findByUserAndUsedAtIsNull(user).size());
+    }
+
+    // ---------------------------------------------------------------
+    // reset-password
+    // ---------------------------------------------------------------
+
+    @Test
+    void resetPassword_validToken_changesPasswordAndConsumesToken() throws Exception {
+        String rawToken = saveTokenFor(user, LocalDateTime.now().plusMinutes(15));
+
+        mockMvc.perform(post("/v1/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                ResetPasswordRequest.builder().token(rawToken).newPassword("N3wPassw0rd!").build())))
+                .andExpect(status().isOk());
+
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        Assertions.assertTrue(passwordEncoder.matches("N3wPassw0rd!", reloaded.getPassword()));
+
+        PasswordResetToken token = passwordResetTokenRepository.findByTokenHash(hash(rawToken)).orElseThrow();
+        Assertions.assertNotNull(token.getUsedAt());
+    }
+
+    @Test
+    void resetPassword_alreadyUsedToken_returns400() throws Exception {
+        String rawToken = saveTokenFor(user, LocalDateTime.now().plusMinutes(15));
+
+        mockMvc.perform(post("/v1/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                ResetPasswordRequest.builder().token(rawToken).newPassword("N3wPassw0rd!").build())))
+                .andExpect(status().isOk());
+
+        // Same token again - already consumed by the call above.
+        mockMvc.perform(post("/v1/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                ResetPasswordRequest.builder().token(rawToken).newPassword("Ano3therPassw0rd!").build())))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void resetPassword_expiredToken_returns400() throws Exception {
+        String rawToken = saveTokenFor(user, LocalDateTime.now().minusMinutes(1));
+
+        mockMvc.perform(post("/v1/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                ResetPasswordRequest.builder().token(rawToken).newPassword("N3wPassw0rd!").build())))
+                .andExpect(status().isBadRequest());
+
+        User reloaded = userRepository.findById(user.getId()).orElseThrow();
+        Assertions.assertTrue(passwordEncoder.matches("OldPassw0rd!", reloaded.getPassword()),
+                "an expired token must not have changed the password");
+    }
+
+    @Test
+    void resetPassword_unknownToken_returns400() throws Exception {
+        mockMvc.perform(post("/v1/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                ResetPasswordRequest.builder().token("not-a-real-token").newPassword("N3wPassw0rd!").build())))
+                .andExpect(status().isBadRequest());
+    }
+
+    private String saveTokenFor(User forUser, LocalDateTime expiresAt) {
+        byte[] bytes = new byte[32];
+        new SecureRandom().nextBytes(bytes);
+        String rawToken = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+
+        passwordResetTokenRepository.save(PasswordResetToken.builder()
+                .user(forUser)
+                .tokenHash(hash(rawToken))
+                .expiresAt(expiresAt)
+                .build());
+        return rawToken;
+    }
+
+    /** Mirrors PasswordResetService's own hashing exactly - see its Javadoc. */
+    private String hash(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(rawToken.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+}

--- a/backend/src/test/java/com/schoolmanagement/service/AuthenticationServiceTest.java
+++ b/backend/src/test/java/com/schoolmanagement/service/AuthenticationServiceTest.java
@@ -38,13 +38,15 @@ class AuthenticationServiceTest {
     private AuthenticationManager authenticationManager;
     @Mock
     private JwtTokenProvider jwtTokenProvider;
+    @Mock
+    private AuditLogService auditLogService;
 
     private AuthenticationService authenticationService;
 
     @BeforeEach
     void setUp() {
         authenticationService = new AuthenticationService(
-                userRepository, passwordEncoder, authenticationManager, jwtTokenProvider);
+                userRepository, passwordEncoder, authenticationManager, jwtTokenProvider, auditLogService);
     }
 
     @Test
@@ -139,7 +141,8 @@ class AuthenticationServiceTest {
         when(jwtTokenProvider.getTokenIssuedAt(anyString())).thenReturn(new Date());
         when(jwtTokenProvider.getTokenExpiration(anyString())).thenReturn(new Date());
 
-        authenticationService.createUserByAdmin(request);
+        User actingAdmin = User.builder().id(1L).role(Role.ADMIN).build();
+        authenticationService.createUserByAdmin(request, actingAdmin);
 
         ArgumentCaptor<User> savedUserCaptor = ArgumentCaptor.forClass(User.class);
         verify(userRepository).save(savedUserCaptor.capture());

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -19,3 +19,11 @@ app:
       # with its own low override + @DirtiesContext, so it doesn't affect
       # every other test's shared state.
       max-requests: 1000
+  auth:
+    forgot-password-rate-limit:
+      # Same reasoning as admissions.rate-limit.max-requests above.
+      max-requests: 1000
+  uploads:
+    # Isolated from the real dev ./uploads dir (still covered by .gitignore's
+    # /uploads/ pattern) so test runs never touch real uploaded files.
+    dir: ./uploads/test


### PR DESCRIPTION
…t/reset password)

Final phase of Giai doan 3, per IMPLEMENTATION_PLAN.md 3.9. Three independent pieces:

1. Document attachments (/v1/documents) - upload/download/list/delete files against a STUDENT/STAFF/ADMISSION_APPLICATION owner (same polymorphic ownerType+ownerId pattern Notification already uses). Local filesystem storage (FileStorageService), chosen over MinIO/S3 per AskUserQuestion - this app deploys as a single self-hosted instance, same reasoning as the in-memory admission rate limiter (3.7). Every stored filename is a server-generated UUID, never derived from the client-supplied original filename, ruling out path traversal. Max 10MB, pdf/jpg/jpeg/png/doc/docx/xls/xlsx only. STUDENT/PARENT limited to their own/child's documents via StudentAccessGuard; STAFF/ADMISSION_APPLICATION owners and all deletes are ADMIN/PRINCIPAL-only.

2. Audit log (/v1/audit-logs, ADMIN-only, paginated) - AuditLogService.log(...) called manually at a deliberately small set of sensitive operations (chosen via AskUserQuestion over a blanket AOP interceptor around every service's create/update/delete, which would have touched 20+ existing services for one phase and buried genuinely sensitive events under routine ones): grade record update/delete, student delete, admission status-change/approve-and-create, ADMIN-created- account role grants, and password reset. Runs in the same transaction as the operation it's logging (no REQUIRES_NEW) - a rolled-back operation must not leave a log entry claiming it happened.

3. Forgot/reset password (/v1/auth/forgot-password, /v1/auth/reset-password, both public) - 256-bit SecureRandom tokens, only the SHA-256 hash ever persisted (a DB leak alone can't be used to reset a password), 15-minute expiry, single-use, and a new request invalidates any still-outstanding earlier token. forgot-password always returns the same generic response regardless of whether the email matches an account (no user enumeration) and is rate-limited per IP via a new ForgotPasswordRateLimitFilter - extracted the actual sliding-window logic into a reusable SlidingWindowRateLimiter so this didn't mean copy-pasting AdmissionRateLimitFilter's already-reviewed internals (AdmissionRateLimitFilter itself is left on its own inline copy rather than migrated, to avoid re-risking already-shipped code for reuse's own sake).

New table: V10__shared_infra.sql (document_attachments, audit_logs, password_reset_tokens). New Flyway-adjacent config: server.servlet.multipart limits (10MB), app.uploads.dir, app.frontend.reset-password-url, app.auth.forgot-password-rate-limit.*.

Touched existing code to thread an actor/User through to the new audit calls: GradeRecordService.updateGradeRecord/deleteGradeRecord, StudentService.deleteStudent, AdmissionService.updateStatus (already had one)/approveAndCreate, AuthenticationService.createUserByAdmin - and their controllers, to pass Authentication through where they didn't already.

Self-review (code-review skill, effort high) on the first pass found and fixed 9 issues before this commit:
- ForgotPasswordRateLimitFilter's lazily-built limiter was a real race (concurrent requests could each build a separate limiter with an empty counter, multiplying the effective rate limit) - now built eagerly in the constructor.
- DocumentService.delete()'s role check silently passed a null requester instead of failing closed, inconsistent with enforceOwnerAccess() in the same class.
- StudentService.deleteStudent() left orphaned DocumentAttachment rows and files on disk (no FK ties them together - it's a polymorphic owner) - now cleans them up first.
- listByOwner had no JOIN FETCH on uploadedBy - N+1 across a page of documents.
- DocumentAttachmentDTO.downloadUrl was missing the /api context-path prefix, so it wasn't actually the routable download URL as documented.
- upload() left an orphaned file on disk if the DB save failed after the file was already written.
- download()'s Content-Disposition used the no-charset filename() overload - would mangle a Vietnamese original filename (very plausible on this system) instead of RFC 5987 percent-encoding it.
- A stale Javadoc {@link} still pointed at createUserByAdmin's old one-argument signature.
- DocumentService/FileStorageService had two near-identical extensionOf() helpers with silently different sanitization - aligned them.

One PasswordResetService/ForgotPasswordRateLimitFilter/DocumentService- specific gotcha hit twice while fixing the above and while first wiring PasswordResetService: mixing Lombok's @AllArgsConstructor with a @Value field breaks Spring startup entirely (Lombok's generated constructor doesn't carry the field's @Value annotation onto its parameter, so Spring tries to autowire a plain String/int/boolean bean and the whole context fails - not just that one bean). Fixed by switching those three classes to an explicit constructor with @Value on the parameter directly; documented the gotcha in each so it doesn't get reintroduced.

Verified:
- mvn -q clean test: 164/164 pass (138 existing + 25 new + 1 more from the self-review's regression test), including fixing 6 existing AdmissionIntegrationTest tests that broke because approveAndCreate now audits itself (needed a real persisted actor, not the test's old transient-principal asAdmin() helper, since AuditLog.actor has a NOT NULL FK to users).
- Live curl against the real running app + real local MySQL: uploaded a real file (confirmed the UUID-named file actually exists on disk under app.uploads.dir, downloaded it back byte-identical), called forgot-password for both a real and a nonexistent email (identical generic response either way, token row created only for the real user, SMTP-unreachable failure caught and logged without breaking the request), and read back /v1/audit-logs showing the real STATUS_CHANGE/APPROVE_AND_CREATE entries from that session's own admissions flow with correct actor/detail JSON.
- Cleaned up all live-test data and uploaded files afterward - verified zero stray rows/files remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure document attachment uploads, downloads, listing, and deletion for students, staff, and admission applications.
  * Added forgot-password and reset-password flows with expiring, single-use reset links.
  * Added administrator-only audit log viewing with filtering and pagination.

* **Security**
  * Added upload validation, access controls, and a 10 MB size limit.
  * Added rate limiting for password-reset requests.
  * Improved tracking of users performing sensitive actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->